### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml
+++ b/pvr.mediaportal.tvserver/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="1.10.7"
+  version="1.11.0"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>

--- a/pvr.mediaportal.tvserver/addon.xml
+++ b/pvr.mediaportal.tvserver/addon.xml
@@ -6,7 +6,7 @@
   provider-name="Marcel Groothuis">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
     <import addon="xbmc.gui" version="5.8.0"/>
   </requires>
   <extension

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v1.11.0
+- Updated to PVR API v1.9.7
+
 v1.10.7
 - Updated language files from Transifex
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -479,7 +479,6 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES *pCapabilities)
   pCapabilities->bSupportsChannelScan        = false;
   pCapabilities->bSupportsRecordingPlayCount = (g_iTVServerXBMCBuild < 117) ? false : true;
   pCapabilities->bSupportsLastPlayedPosition = (g_iTVServerXBMCBuild < 121) ? false : true;
-  pCapabilities->bSupportsRecordingFolders   = false; // Don't show the timer directory field. This does not influence the displaying directories in the recordings list.
 
   return PVR_ERROR_NO_ERROR;
 }
@@ -702,6 +701,12 @@ int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
 /*******************************************/
 /** PVR Timer Functions                   **/
 
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+  /* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 int GetTimersAmount(void)
 {
   if (!g_client)
@@ -712,6 +717,7 @@ int GetTimersAmount(void)
 
 PVR_ERROR GetTimers(ADDON_HANDLE handle)
 {
+  /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
   if (!g_client)
     return PVR_ERROR_SERVER_ERROR;
   else
@@ -726,8 +732,9 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
     return g_client->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/)
 {
+  /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
   if (!g_client)
     return PVR_ERROR_SERVER_ERROR;
   else

--- a/src/timers.cpp
+++ b/src/timers.cpp
@@ -112,7 +112,7 @@ cTimer::cTimer(const PVR_TIMER& timerinfo)
 
   SetKeepMethod(timerinfo.iLifetime);
 
-  if(timerinfo.bIsRepeating)
+  if(timerinfo.iWeekdays != PVR_WEEKDAY_NONE) // repeating?
   {
     m_schedtype = RepeatFlags2SchedRecType(timerinfo.iWeekdays);
     m_series = true;
@@ -139,6 +139,9 @@ cTimer::~cTimer()
 void cTimer::GetPVRtimerinfo(PVR_TIMER &tag)
 {
   memset(&tag, 0, sizeof(tag));
+
+  /* TODO: Implement own timer types to get support for the timer features introduced with PVR API 1.9.7 */
+  tag.iTimerType = PVR_TIMER_TYPE_NONE;
 
   if (m_progid != -1)
   {
@@ -180,7 +183,6 @@ void cTimer::GetPVRtimerinfo(PVR_TIMER &tag)
   }
   tag.iPriority         = Priority();
   tag.iLifetime         = GetLifetime();
-  tag.bIsRepeating      = Repeat();
   tag.iWeekdays         = RepeatFlags();
   tag.iMarginStart      = m_prerecordinterval;
   tag.iMarginEnd        = m_postrecordinterval;


### PR DESCRIPTION
For, J***\* PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J***\* and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.
