### PR TITLE
Fix: ts timeShift file is locked after call to GetLiveStreamURL(), although no read request has been sent to pvr.mediaportal.tvserver addon.

### DIFF
--- a/src/lib/tsreader/FileReader.h
+++ b/src/lib/tsreader/FileReader.h
@@ -50,6 +50,7 @@ namespace MPTV
         virtual long OpenFile(const std::string& fileName);
         virtual long OpenFile();
         virtual long CloseFile();
+        virtual long CloseTSTimeShiftFile() { return S_OK; };
         virtual long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
         virtual bool IsFileInvalid();
         virtual int64_t SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod);

--- a/src/lib/tsreader/MultiFileReader.cpp
+++ b/src/lib/tsreader/MultiFileReader.cpp
@@ -139,7 +139,7 @@ namespace MPTV
         std::vector<MultiFileReaderFile *>::iterator it;
 
         m_TSBufferFile.CloseFile();
-        hr = m_TSFile.CloseFile();
+        hr = CloseTSTimeShiftFile();
 
         for (it = m_tsFiles.begin(); it < m_tsFiles.end(); ++it)
         {
@@ -149,6 +149,14 @@ namespace MPTV
 
         m_TSFileId = 0;
         return hr;
+    }
+
+    //
+    // Close TimeShift TS File
+    //
+    long MultiFileReader::CloseTSTimeShiftFile()
+    {
+        return m_TSFile.CloseFile();
     }
 
     bool MultiFileReader::IsFileInvalid()

--- a/src/lib/tsreader/MultiFileReader.h
+++ b/src/lib/tsreader/MultiFileReader.h
@@ -58,6 +58,7 @@ namespace MPTV
         virtual long OpenFile();
         virtual long OpenFile(const std::string& fileName);
         virtual long CloseFile();
+        virtual long CloseTSTimeShiftFile();
         virtual long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
 
         virtual bool IsFileInvalid();

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -278,6 +278,16 @@ namespace MPTV
             m_demultiplexer.Start();
 
             m_fileReader->SetFilePointer(0LL, FILE_BEGIN);
+            if (m_bTimeShifting)
+            {
+                // Unlock ts timeShift file.
+                // This will allow mp tvserver to write(or delete) to ts timeShift files
+                // while TSReader is idle after file opening.
+                // e.g when stream url has been opened by external reader with GetLiveStreamURL().
+                // ts timeShift file will be loaded again on the first read request.
+                m_fileReader->CloseTSTimeShiftFile();
+            }
+
             m_State = State_Running;
         }
         return S_OK;
@@ -358,6 +368,13 @@ namespace MPTV
 
                 m_demultiplexer.RequestNewPat();
                 fileReader->OnChannelChange();
+
+                // Unlock ts timeShift file.
+                // This will allow mp tvserver to write(or delete) to ts timeShift files
+                // while TSReader is idle after channel switching.
+                // e.g when stream url has been opened by external reader with GetLiveStreamURL().
+                // ts timeShift file will be loaded again on the first read request.
+                fileReader->CloseTSTimeShiftFile();
 
                 XBMC->Log(LOG_DEBUG, "%s:: move from %I64d to %I64d tsbufpos  %I64d", __FUNCTION__, pos_before, pos_after, timeShiftBufferPos);
                 usleep(100000);


### PR DESCRIPTION
Hi,

I use `cPVRClientMediaPortal::GetLiveStreamURL()` method to get RTSP url and pass it to the external reader([DSPlayer](http://forum.kodi.tv/showthread.php?tid=223175&pid=2015166#pid2015166)). 
After some time of live tv streaming, the picture freezes and i get error from MediaPortal tvserver, tswriter log:

```
[2015-06-12 20:53:20,069] [8ec1fa0] [24bc] - MultiFileWriter: failed to create file \\HOSTNAME-PC\Timeshift\live5-0.ts.tsbuffer1.ts
[2015-06-12 20:59:42,443] [8ec1fa0] [24bc] - MultiFileWriter: failed to create file \\HOSTNAME-PC\Timeshift\live5-0.ts.tsbuffer1.ts
[2015-06-12 21:06:08,062] [8ec1fa0] [24bc] - MultiFileWriter: failed to create file \\HOSTNAME-PC\Timeshift\live5-0.ts.tsbuffer1.ts
[2015-06-12 21:06:08,062] [8ec1fa0] [24bc] - Failed to reopen old file. It's currently in use. Dropping data!
[2015-06-12 21:06:08,667] [8ec1fa0] [24bc] - MultiFileWriter: failed to create file \\HOSTNAME-PC\Timeshift\live5-0.ts.tsbuffer1.ts
[2015-06-12 21:06:08,667] [8ec1fa0] [24bc] - Failed to reopen old file. It's currently in use. Dropping data!
```

This error occur although that the internal tsreader is on idle(read method has not been called) and although that the locked file(live5-0.ts.tsbuffer1.ts) is not opened by the external reader. 
The reason for this problem is that this file has been opened by demultiplexer when tsreader has opened tsbuffer file(live5-0.ts.tsbuffer).

```
// detect audio/video pids
m_demultiplexer.SetFileReader(m_fileReader);
m_demultiplexer.Start();
```

The same situation occurs on channel switching, ts timeshift file remains open after -  `m_demultiplexer.RequestNewPat()` method has been executed.

To fix this, i close ts timeshift file after demultiplexer function call. 
ts timeshift file will be loaded again on first read request to pvr.mediaportal.tvserver addon. 

Roman.
