### PR TITLE
Bump add-on for PVR API 3.0.0 (Compatibility mode)

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="1.11.3"
+  version="1.11.4"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="2.1.0"/>
+    <import addon="xbmc.pvr" version="3.0.0"/>
     <import addon="xbmc.gui" version="5.8.0"/>
   </requires>
   <extension

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v1.11.4
+- Updated to PVR API v3.0.0 (API 1.9.7 compatibility mode)
+
 v1.11.3
 - Updated to PVR API v2.1.0
 - Automatically fill in platform and library name


### PR DESCRIPTION
Addon part of xbmc/xbmc#7626
Add on currently using 1.9.7 API compatibility code
No further changes required for minimal support
