### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="1.11.5"
+  version="1.11.6"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
     <import addon="xbmc.gui" version="5.8.0"/>
   </requires>
   <extension

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v1.11.6
+- Updated to PVR API v4.1.0
+
 v1.11.5
 - Updated to PVR API v4.0.0
 

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -511,6 +511,7 @@ PVR_ERROR cPVRClientMediaPortal::GetEpg(ADDON_HANDLE handle, const PVR_CHANNEL &
             broadcast.iEpisodeNumber      = epg.EpisodeNumber();
             broadcast.iEpisodePartNumber  = atoi(epg.EpisodePart());
             broadcast.strEpisodeName      = epg.EpisodeName();
+            broadcast.iFlags              = EPG_TAG_FLAG_UNDEFINED;
 
             PVR->TransferEpgEntry(handle, &broadcast);
           }


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075
