### PR TITLE
Fix regression with handling of epg ids and timer indexes introduced with PVR API 4.0.0 bump

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="1.11.6"
+  version="1.11.7"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v1.11.7
+- Fixed a regression with timer id and epg id handling introduced with PVR API v4.0.0
+
 v1.11.6
 - Updated to PVR API v4.1.0
 

--- a/src/timers.h
+++ b/src/timers.h
@@ -76,7 +76,7 @@ class cTimer
     virtual ~cTimer();
 
     void GetPVRtimerinfo(PVR_TIMER &tag);
-    unsigned int Index(void) const { return m_index; }
+    int Index(void) const { return m_index; }
     unsigned int Channel(void) const { return m_channel; }
     int Priority(void) { return Mepo2XBMCPriority(m_priority); }
     const char* Title(void) const { return m_title.c_str(); }
@@ -114,8 +114,8 @@ class cTimer
     int Mepo2XBMCPriority(int mepoprio);
 
     // MediaPortal database fields:
-    unsigned int m_index;              ///> MediaPortal id_Schedule
-    int          m_channel;            ///> MediaPortal idChannel
+    int         m_index;               ///> MediaPortal id_Schedule
+    int         m_channel;             ///> MediaPortal idChannel
     TvDatabase::ScheduleRecordingType m_schedtype; ///> MediaPortal scheduleType
     std::string m_title;               ///> MediaPortal programName
     MPTV::CDateTime m_startTime;       ///> MediaPortal startTime
@@ -139,7 +139,7 @@ class cTimer
     bool        m_ismanual;
     bool        m_isrecording;
 
-    unsigned int m_progid;             ///> MediaPortal Program ID
+    int         m_progid;              ///> MediaPortal Program ID
 };
 
 #endif //__TIMERS_H


### PR DESCRIPTION
@margro does this fix the issues you reported here https://github.com/kodi-pvr/pvr.mediaportal.tvserver/pull/23#issuecomment-141667000 ?
