### PR TITLE
Updated to PVR API v4.2.0

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="2.0.1"
+  version="2.0.2"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.1.0"/>
+    <import addon="xbmc.pvr" version="4.2.0"/>
     <import addon="kodi.guilib" version="5.10.0"/>
   </requires>
   <extension

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v2.0.2
+- Updated to PVR API v4.2.0
+
 v2.0.1
 - Updated language files from Transifex
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -813,6 +813,14 @@ long long LengthLiveStream(void)
     return g_client->LengthLiveStream();
 }
 
+bool IsRealTimeStream(void)
+{
+  if (g_client == NULL)
+    return false;
+
+  return g_client->IsRealTimeStream();
+}
+
 int GetCurrentClientChannel()
 {
   if (!g_client)

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -1529,6 +1529,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const PVR_CHANNEL &channelinfo)
   if (!IsUp())
   {
     m_iCurrentChannel = -1;
+    m_bTimeShiftStarted = false;
     m_signalStateCounter = 0;
     XBMC->Log(LOG_ERROR, "Open Live stream failed. No connection to backend.");
     return false;
@@ -1542,6 +1543,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const PVR_CHANNEL &channelinfo)
 
   m_iCurrentChannel = -1; // make sure that it is not a valid channel nr in case it will fail lateron
   m_signalStateCounter = 0;
+  m_bTimeShiftStarted = false;
 
   // Start the timeshift
   // Use the optimized TimeshiftChannel call (don't stop a running timeshift)
@@ -1800,7 +1802,7 @@ void cPVRClientMediaPortal::CloseLiveStream(void)
   string result;
 
   if (!IsUp())
-     return;
+    return;
 
   if (m_bTimeShiftStarted)
   {
@@ -1854,6 +1856,11 @@ long long cPVRClientMediaPortal::PositionLiveStream(void)
     return -1;
   }
   return m_tsreader->GetFilePointer();
+}
+
+bool cPVRClientMediaPortal::IsRealTimeStream(void)
+{
+  return m_bTimeShiftStarted;
 }
 
 bool cPVRClientMediaPortal::SwitchChannel(const PVR_CHANNEL &channel)
@@ -1954,6 +1961,9 @@ PVR_ERROR cPVRClientMediaPortal::SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
 bool cPVRClientMediaPortal::OpenRecordedStream(const PVR_RECORDING &recording)
 {
   XBMC->Log(LOG_NOTICE, "OpenRecordedStream (id=%s)", recording.strRecordingId);
+
+  m_bTimeShiftStarted = false;
+
   if (!IsUp())
     return false;
 

--- a/src/pvrclient-mediaportal.h
+++ b/src/pvrclient-mediaportal.h
@@ -100,6 +100,7 @@ public:
   long long PositionLiveStream(void);
   bool CanPauseAndSeek(void);
   void PauseStream(bool bPaused);
+  bool IsRealTimeStream(void);
 
   /* Record stream handling */
   bool OpenRecordedStream(const PVR_RECORDING &recording);
@@ -131,7 +132,7 @@ private:
   time_t                  m_BackendTime;
   CCards                  m_cCards;
   CGenreTable*            m_genretable;
-  P8PLATFORM::CMutex        m_mutex;
+  P8PLATFORM::CMutex      m_mutex;
   int64_t                 m_iLastRecordingUpdate;
   MPTV::CTsReader*        m_tsreader;
   std::map<int,std::string> m_channelNames;


### PR DESCRIPTION
The required modifications for PVR API 4.2.0 (indicate whether a stream is a livestream)
