### PR TITLE
Set recording episode name to correct place

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="2.4.7"
+  version="2.4.8"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>

--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="2.4.6"
+  version="2.4.7"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v2.4.7
+- Fixed: PVR recordings episode name being set to subplot.
+
 v2.4.6
 - Fixed: various Coverity reported issues for Live555
 

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -969,6 +969,7 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordings(ADDON_HANDLE handle)
       strEpisodeName = recording.EpisodeName();
 
       PVR_STRCPY(tag.strRecordingId, strRecordingId.c_str());
+	  PVR_STRCPY(tag.strEpisodeName, recording.EpisodeName());
       PVR_STRCPY(tag.strTitle, recording.Title());
       PVR_STRCPY(tag.strPlotOutline, recording.EpisodeName());
       PVR_STRCPY(tag.strPlot, recording.Description());

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -969,8 +969,8 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordings(ADDON_HANDLE handle)
       strEpisodeName = recording.EpisodeName();
 
       PVR_STRCPY(tag.strRecordingId, strRecordingId.c_str());
-	  PVR_STRCPY(tag.strEpisodeName, recording.EpisodeName());
       PVR_STRCPY(tag.strTitle, recording.Title());
+      PVR_STRCPY(tag.strEpisodeName, recording.EpisodeName());
       PVR_STRCPY(tag.strPlot, recording.Description());
       PVR_STRCPY(tag.strChannelName, recording.ChannelName());
       tag.iChannelUid    = recording.ChannelID();

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -971,7 +971,6 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordings(ADDON_HANDLE handle)
       PVR_STRCPY(tag.strRecordingId, strRecordingId.c_str());
 	  PVR_STRCPY(tag.strEpisodeName, recording.EpisodeName());
       PVR_STRCPY(tag.strTitle, recording.Title());
-      PVR_STRCPY(tag.strPlotOutline, recording.EpisodeName());
       PVR_STRCPY(tag.strPlot, recording.Description());
       PVR_STRCPY(tag.strChannelName, recording.ChannelName());
       tag.iChannelUid    = recording.ChannelID();


### PR DESCRIPTION
The episode name was being set to strPlotOutline not strEpisodeName
