### PR TITLE
Update to 3.0.1

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="3.0.0"
+  version="3.0.1"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v3.0.1
+- Added support for the recording channelType property to distinguish between radio and tv recordings (requires TVServerKodi v1.15.0.136 or above)
+
 v3.0.0
 - Initial Kodi v18 version
 

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,6 +1,8 @@
 v3.0.1
 - Add support for asynchronous connect. The addon will now regularly try to connect to the backend if it is not connected already.
 - Added support for the recording channelType property to distinguish between radio and tv recordings (requires TVServerKodi v1.15.0.136 or above)
+- Added a fallback for in-progress recording playback using the TSReader. When the filename is empty, try the RTSP url and vice versa.
+- OpenRecordedStream: send additional error messages to the log in case things fail here.
 
 v3.0.0
 - Initial Kodi v18 version

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,4 +1,5 @@
 v3.0.1
+- Add support for asynchronous connect. The addon will now regularly try to connect to the backend if it is not connected already.
 - Added support for the recording channelType property to distinguish between radio and tv recordings (requires TVServerKodi v1.15.0.136 or above)
 
 v3.0.0

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -7,6 +7,9 @@ v3.0.1
 v3.0.0
 - Initial Kodi v18 version
 
+V2.4.9
+- Adapt to API change - SeekTime
+
 v2.4.8
 - Add Estuary skin support for the old series timer dialog
 - Fixed: various Coverity reported issues for Live555 (part 2)

--- a/src/GUIDialogRecordSettings.cpp
+++ b/src/GUIDialogRecordSettings.cpp
@@ -69,11 +69,11 @@ CGUIDialogRecordSettings::CGUIDialogRecordSettings(const PVR_TIMER &timerinfo, c
 
   // needed for every dialog
   m_retVal = -1;				// init to failed load value (due to xml file not being found)
-  // Default skin should actually be "skin.confluence", but the fallback mechanism will only
+  // Default skin should actually be "skin.estuary", but the fallback mechanism will only
   // find the xml file and not the used image files. This will result in a transparent window
   // which is basically useless. Therefore, it is better to let the dialog fail by using the
   // incorrect fallback skin name "Confluence"
-  m_window = GUI->Window_create("DialogRecordSettings.xml", "skin.confluence", false, true);
+  m_window = GUI->Window_create("DialogRecordSettings.xml", "skin.estuary", false, true);
   if (m_window)
   {
     m_window->m_cbhdl = this;

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -400,8 +400,9 @@ bool Socket::connect ( const std::string& host, const unsigned short port )
   }
   _port = port;
 
-  char strPort[15];
+  char strPort[16];
   snprintf(strPort, 15, "%hu", port);
+  strPort[15] = '\0';
 
   struct addrinfo hints;
   struct addrinfo* result = NULL;

--- a/src/channels.h
+++ b/src/channels.h
@@ -24,6 +24,19 @@
 #include "libXBMC_pvr.h"
 #include <string>
 
+namespace TvDatabase
+{
+  // From MediaPortal: TvDatabase.ChannelType
+  namespace ChannelType
+  {
+    const int Unknown = -1; //Added
+    const int Tv = 0;
+    const int Radio = 1;
+    const int Web = 2;
+    const int All = 3;
+  };
+}
+
 class cChannel
 {
 private:

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -49,8 +49,8 @@ int g_iTVServerXBMCBuild = 0;
 /* TVServerXBMC plugin supported versions */
 #define TVSERVERXBMC_MIN_VERSION_STRING         "1.1.7.107"
 #define TVSERVERXBMC_MIN_VERSION_BUILD          107
-#define TVSERVERXBMC_RECOMMENDED_VERSION_STRING "1.2.3.122 till 1.15.0.134"
-#define TVSERVERXBMC_RECOMMENDED_VERSION_BUILD  134
+#define TVSERVERXBMC_RECOMMENDED_VERSION_STRING "1.2.3.122 till 1.15.0.136"
+#define TVSERVERXBMC_RECOMMENDED_VERSION_BUILD  136
 
 /************************************************************/
 /** Class interface */
@@ -985,9 +985,7 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordings(ADDON_HANDLE handle)
       tag.iEpisodeNumber = recording.GetEpisodeNumber();
       tag.iSeriesNumber  = recording.GetSeriesNumber();
       tag.iEpgEventId    = EPG_TAG_INVALID_UID;
-
-      /* TODO: PVR API 5.1.0: Implement this */
-      tag.channelType = PVR_RECORDING_CHANNEL_TYPE_UNKNOWN;
+      tag.channelType    = recording.GetChannelType();
 
       strDirectory = recording.Directory();
       if (strDirectory.length() > 0)

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -108,59 +108,35 @@ string cPVRClientMediaPortal::SendCommand(string command)
       }
       else
       {
-        XBMC->Log(LOG_ERROR, "SendCommand2: reconnect failed.");
+        XBMC->Log(LOG_ERROR, "SendCommand: reconnect failed.");
         return "";
-      }
-    }
-  }
-
-  string line;
-
-  if ( !m_tcpclient->ReadLine( line ) )
-  {
-    XBMC->Log(LOG_ERROR, "SendCommand - Failed.");
-  }
-  return line;
-}
-
-bool cPVRClientMediaPortal::SendCommand2(string command, vector<string>& lines)
-{
-  P8PLATFORM::CLockObject critsec(m_mutex);
-
-  if ( !m_tcpclient->send(command) )
-  {
-    if ( !m_tcpclient->is_valid() )
-    {
-      XBMC->Log(LOG_ERROR, "SendCommand2: connection lost, attempt to reconnect...");
-      // Connection lost, try to reconnect
-      if ( Connect() == ADDON_STATUS_OK )
-      {
-        // Resend the command
-        if (!m_tcpclient->send(command))
-        {
-          XBMC->Log(LOG_ERROR, "SendCommand2('%s') failed.", command.c_str());
-          return false;
-        }
-      }
-      else
-      {
-        XBMC->Log(LOG_ERROR, "SendCommand2: reconnect failed.");
-        return false;
       }
     }
   }
 
   string result;
 
-  if (!m_tcpclient->ReadLine(result))
+  if ( !m_tcpclient->ReadLine( result ) )
   {
-    XBMC->Log(LOG_ERROR, "SendCommand2 - Failed.");
-    return false;
+    XBMC->Log(LOG_ERROR, "SendCommand - Failed.");
+    return "";
   }
 
   if (result.find("[ERROR]:") != std::string::npos)
   {
-    XBMC->Log(LOG_ERROR, "TVServerXBMC error: %s", result.c_str());
+    XBMC->Log(LOG_ERROR, "TVServerKodi error: %s", result.c_str());
+  }
+
+  return result;
+}
+
+
+bool cPVRClientMediaPortal::SendCommand2(string command, vector<string>& lines)
+{
+  string result = SendCommand(command);
+
+  if (result.empty())
+  {
     return false;
   }
 

--- a/src/recordings.cpp
+++ b/src/recordings.cpp
@@ -30,7 +30,8 @@ using namespace std;
 
 using namespace ADDON;
 
-cRecording::cRecording()
+cRecording::cRecording() :
+  m_channelType(TvDatabase::ChannelType::Unknown)
 {
   m_duration        = 0;
   m_Index           = -1;
@@ -85,6 +86,7 @@ bool cRecording::ParseLine(const std::string& data)
     //[18] isrecording (bool)
     //[19] timesWatched (int)
     //[20] stopTime (int)
+    //[21] channelType (int)
 
     m_Index = atoi(fields[0].c_str());
 
@@ -170,6 +172,14 @@ bool cRecording::ParseLine(const std::string& data)
         if (fields.size() >= 21) // Since TVServerXBMC 1.2.x.121
         {
           m_lastPlayedPosition = atoi( fields[20].c_str() );
+          if (fields.size() >= 22) // Since TVServerKodi 1.15.136
+          {
+            m_channelType = atoi(fields[21].c_str());
+          }
+          else
+          {
+            m_channelType = TvDatabase::ChannelType::Unknown;
+          }
         }
       }
     }
@@ -329,4 +339,19 @@ int cRecording::GetEpisodeNumber(void) const
     return -1;
 
   return atoi(m_episodeNumber.c_str());
+}
+
+PVR_RECORDING_CHANNEL_TYPE cRecording::GetChannelType(void) const
+{
+  switch (m_channelType)
+  {
+  case TvDatabase::ChannelType::Tv:
+    return PVR_RECORDING_CHANNEL_TYPE_TV;
+    break;
+  case TvDatabase::ChannelType::Radio:
+    return PVR_RECORDING_CHANNEL_TYPE_RADIO;
+    break;
+  default:
+    return PVR_RECORDING_CHANNEL_TYPE_UNKNOWN;
+  }
 }

--- a/src/recordings.cpp
+++ b/src/recordings.cpp
@@ -188,6 +188,7 @@ bool cRecording::ParseLine(const std::string& data)
   }
   else
   {
+    XBMC->Log(LOG_ERROR, "Recording information has not enough fields. At least 9 fields expected, got only %d fields.", fields.size());
     return false;
   }
 }

--- a/src/recordings.h
+++ b/src/recordings.h
@@ -23,7 +23,7 @@
 #include "Cards.h"
 #include "GenreTable.h"
 #include "DateTime.h"
-
+#include "channels.h"
 
 #define DEFAULTFRAMESPERSECOND 25.0
 #define MAXPRIORITY 99
@@ -44,9 +44,9 @@ private:
   MPTV::CDateTime m_startTime;
   MPTV::CDateTime m_endTime;
   int m_duration;
-  std::string m_title;             // Title of this event
-  std::string m_description;       // Description of this event
-  std::string m_episodeName;       // Short description of this event (typically the episode name in case of a series)
+  std::string m_title;             ///< Title of this event
+  std::string m_description;       ///< Description of this event
+  std::string m_episodeName;       ///< Short description of this event (typically the episode name in case of a series)
   std::string m_seriesNumber;
   std::string m_episodeNumber;
   std::string m_episodePart;
@@ -61,6 +61,7 @@ private:
   CGenreTable* m_genretable;
   int m_timesWatched;
   int m_lastPlayedPosition;
+  int m_channelType;
 
 public:
   cRecording();
@@ -83,6 +84,7 @@ public:
   int LastPlayedPosition(void) const { return m_lastPlayedPosition; }
   bool IsRecording(void) {return m_isRecording; }
   int ChannelID(void) const { return m_channelID; }
+  PVR_RECORDING_CHANNEL_TYPE GetChannelType(void) const;
 
   /**
    * \brief Filename of this recording with full path (at server side)


### PR DESCRIPTION
- Add support for asynchronous connect. The addon will now regularly try to connect to the backend if it is not connected already.
- Added support for the recording channelType property to distinguish between radio and tv recordings (requires TVServerKodi v1.15.0.136 or above)
- Added a fallback for in-progress recording playback using the TSReader. When the filename is empty, try the RTSP url and vice versa.
- OpenRecordedStream: send additional error messages to the log in case things fail here.
