### PR TITLE
[Travis] Fixed: build against the Krypton branch of Kodi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 #
 before_script:
   - cd $TRAVIS_BUILD_DIR/..
-  - git clone --depth=1 https://github.com/xbmc/xbmc.git
+  - git clone --depth=1 -b Krypton https://github.com/xbmc/xbmc.git
   - cd pvr.mediaportal.tvserver && mkdir build && cd build
   - cmake -DADDONS_TO_BUILD=pvr.mediaportal.tvserver -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/project/cmake/addons
 


### PR DESCRIPTION
Current build script clones the master branch of Kodi which results in build failures