### PR TITLE
Pvr api 5 6 0

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="3.1.0"
+  version="3.2.0"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,7 @@
+v3.2.0
+- Updated to PVR addon API v5.6.0
+- Removed GetLiveStreamURL functionality.
+
 v3.1.0
 - Updated to PVR addon API v5.3.0
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -867,14 +867,6 @@ long long LengthRecordedStream(void)
     return g_client->LengthRecordedStream();
 }
 
-const char * GetLiveStreamURL(const PVR_CHANNEL &channel)
-{
-  if (!g_client)
-    return "";
-  else
-    return g_client->GetLiveStreamURL(channel);
-}
-
 bool CanPauseStream(void)
 {
   if (g_client)
@@ -897,6 +889,32 @@ bool CanSeekStream(void)
   return false;
 }
 
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
+{
+  if ((!channel) || (!properties) || (!iPropertiesCount) || (!g_client))
+  {
+    return PVR_ERROR_FAILED;
+  }
+
+  if (*iPropertiesCount < 1)
+    return PVR_ERROR_INVALID_PARAMETERS;
+
+  return g_client->GetChannelStreamProperties(channel, properties, iPropertiesCount);
+}
+
+PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
+{
+  if ((!recording) || (!properties) || (!iPropertiesCount) || (!g_client))
+  {
+    return PVR_ERROR_FAILED;
+  }
+
+  if (*iPropertiesCount < 1)
+    return PVR_ERROR_INVALID_PARAMETERS;
+
+  return g_client->GetRecordingStreamProperties(recording, properties, iPropertiesCount);
+}
+
 /** UNUSED API FUNCTIONS */
 PVR_ERROR MoveChannel(const PVR_CHANNEL& UNUSED(channel)) { return PVR_ERROR_NOT_IMPLEMENTED; }
 DemuxPacket* DemuxRead(void) { return NULL; }
@@ -917,4 +935,5 @@ PVR_ERROR DeleteAllRecordingsFromTrash() { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 } //end extern "C"

--- a/src/lib/live555/groupsock/GroupsockHelper.cpp
+++ b/src/lib/live555/groupsock/GroupsockHelper.cpp
@@ -232,7 +232,7 @@ int setupStreamSocket(UsageEnvironment& env,
 static int blockUntilReadable(UsageEnvironment& env,
 			      int socket, struct timeval* timeout) {
   int result = -1;
-  bool keepTrying = true;
+  bool keepTrying = false;
   do {
     fd_set rd_set;
     FD_ZERO(&rd_set);
@@ -248,6 +248,7 @@ static int blockUntilReadable(UsageEnvironment& env,
       int err = env.getErrno();
       if (err == EINTR || err == EAGAIN || err == EWOULDBLOCK)
       {
+        keepTrying = true;
         continue;
       }
       else

--- a/src/lib/tsreader/DeMultiplexer.cpp
+++ b/src/lib/tsreader/DeMultiplexer.cpp
@@ -129,15 +129,21 @@ namespace MPTV
 
             if (nBytesToRead)
             {
-                // then read raw data from the buffer
-                m_reader->Read(buffer, nBytesToRead, (unsigned long*)&dwReadBytes);
+              // then read raw data from the buffer
+              if (SUCCEEDED(m_reader->Read(buffer, nBytesToRead, (unsigned long*)&dwReadBytes)))
+              {
                 if (dwReadBytes > 0)
                 {
-                    // yes, then process the raw data
-                    //result=true;
-                    OnRawData(buffer, (int)dwReadBytes);
-                    m_LastDataFromRtsp = GetTickCount();
+                  // yes, then process the raw data
+                  //result=true;
+                  OnRawData(buffer, (int)dwReadBytes);
+                  m_LastDataFromRtsp = GetTickCount();
                 }
+              }
+              else
+              {
+                XBMC->Log(LOG_DEBUG, "%s: Read failed...", __FUNCTION__);
+              }
             }
             else
             {

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -2173,13 +2173,25 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordingStreamProperties(const PVR_RECORDIN
 
 PVR_ERROR cPVRClientMediaPortal::GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
 {
-  if (g_eStreamingMethod == ffmpeg && !m_PlaybackURL.empty())
+  if (g_eStreamingMethod == ffmpeg)
   {
-    XBMC->Log(LOG_NOTICE, "GetChannelStreamProperties for uid=%i is '%s'", channel->iUniqueId, m_PlaybackURL.c_str());
-    PVR_STRCPY(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL);
-    PVR_STRCPY(properties[0].strValue, m_PlaybackURL.c_str());
-    *iPropertiesCount = 1;
-    return PVR_ERROR_NO_ERROR;
+    // GetChannelStreamProperties is called before OpenLiveStream by Kodi, so we should already open the stream here...
+    // The actual call to OpenLiveStream will return immediately since we've already tuned the correct channel here.
+    if (m_bTimeShiftStarted == true)
+    {
+      //CloseLiveStream();
+    }
+    if (OpenLiveStream(*channel) == true)
+    {
+      if (!m_PlaybackURL.empty())
+      {
+        XBMC->Log(LOG_NOTICE, "GetChannelStreamProperties for uid=%i is '%s'", channel->iUniqueId, m_PlaybackURL.c_str());
+        PVR_STRCPY(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL);
+        PVR_STRCPY(properties[0].strValue, m_PlaybackURL.c_str());
+        *iPropertiesCount = 1;
+        return PVR_ERROR_NO_ERROR;
+      }
+    }
   }
   else if (g_eStreamingMethod == TSReader)
   {

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -334,8 +334,10 @@ void* cPVRClientMediaPortal::Process(void)
     case PVR_CONNECTION_STATE_SERVER_MISMATCH:
     case PVR_CONNECTION_STATE_VERSION_MISMATCH:
       keepWaiting = false;
+      break;
     case PVR_CONNECTION_STATE_CONNECTED:
       keepWaiting = false;
+      break;
     default:
       break;
     }
@@ -1859,6 +1861,7 @@ void cPVRClientMediaPortal::CloseLiveStream(void)
     m_bTimeShiftStarted = false;
     m_iCurrentChannel = -1;
     m_iCurrentCard = -1;
+    m_PlaybackURL.clear();
 
     m_signalStateCounter = 0;
   }
@@ -2170,19 +2173,25 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordingStreamProperties(const PVR_RECORDIN
 
 PVR_ERROR cPVRClientMediaPortal::GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
 {
-  if (!m_PlaybackURL.empty())
+  if (g_eStreamingMethod == ffmpeg && !m_PlaybackURL.empty())
   {
     XBMC->Log(LOG_NOTICE, "GetChannelStreamProperties for uid=%i is '%s'", channel->iUniqueId, m_PlaybackURL.c_str());
     PVR_STRCPY(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL);
     PVR_STRCPY(properties[0].strValue, m_PlaybackURL.c_str());
     *iPropertiesCount = 1;
+    return PVR_ERROR_NO_ERROR;
+  }
+  else if (g_eStreamingMethod == TSReader)
+  {
+    XBMC->Log(LOG_DEBUG, "GetChannelStreamProperties: no properties set for uid=%i because TSReader is active", channel->iUniqueId);
   }
   else
   {
     XBMC->Log(LOG_ERROR, "GetChannelStreamProperties for uid=%i returned no URL", channel->iUniqueId);
-    *iPropertiesCount = 0;
   }
-  
+
+  *iPropertiesCount = 0;
+
   return PVR_ERROR_NO_ERROR;
 } 
 

--- a/src/pvrclient-mediaportal.h
+++ b/src/pvrclient-mediaportal.h
@@ -91,7 +91,7 @@ public:
   int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize);
   bool SwitchChannel(const PVR_CHANNEL &channel);
   PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus);
-  const char* GetLiveStreamURL(const PVR_CHANNEL &channel);
+  PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount);
   long long SeekLiveStream(long long iPosition, int iWhence = SEEK_SET);
   long long LengthLiveStream(void);
   long long PositionLiveStream(void);
@@ -106,6 +106,7 @@ public:
   long long SeekRecordedStream(long long iPosition, int iWhence = SEEK_SET);
   long long LengthRecordedStream(void);
   long long PositionRecordedStream(void);
+  PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING* recording, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount);
 
 protected:
   MPTV::Socket           *m_tcpclient;
@@ -131,7 +132,7 @@ private:
   std::string             m_PlaybackURL;
   std::string             m_BackendName;
   std::string             m_BackendVersion;
-  time_t                  m_BackendUTCoffset;
+  int                     m_BackendUTCoffset;
   time_t                  m_BackendTime;
   CCards                  m_cCards;
   CGenreTable*            m_genretable;


### PR DESCRIPTION
Make the addon compatible with PVR API 5.6.0.

Proper implementation of GetChannelStreamProperties() and GetRecordingStreamProperties() for ffmpeg rtsp playback is still work in progress, but with this PR, the addon is at least usable again in TSReader mode. 