### PR TITLE
live555: remove xlocale.h from Locale.hh

### DIFF
--- a/src/lib/live555/liveMedia/include/Locale.hh
+++ b/src/lib/live555/liveMedia/include/Locale.hh
@@ -43,9 +43,6 @@ along with this library; if not, write to the Free Software Foundation, Inc.,
 
 #ifndef LOCALE_NOT_USED
 #include <locale.h>
-#ifndef XLOCALE_NOT_USED
-#include <xlocale.h> // because, on some systems, <locale.h> doesn't include <xlocale.h>; this makes sure that we get both
-#endif
 #endif
 
 


### PR DESCRIPTION
Fixes build error with glibc 2.26:
https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>