### PR TITLE
[fix] allow building with glibc 2.26 or newer

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="3.4.0"
+  version="3.4.1"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/lib/live555/liveMedia/include/Locale.hh
+++ b/src/lib/live555/liveMedia/include/Locale.hh
@@ -43,7 +43,7 @@ along with this library; if not, write to the Free Software Foundation, Inc.,
 
 #ifndef LOCALE_NOT_USED
 #include <locale.h>
-#ifndef XLOCALE_NOT_USED
+#if !defined(XLOCALE_NOT_USED) && (!defined(__GLIBC__) || !defined(__GLIBC_MINOR__) || __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 26))
 #include <xlocale.h> // because, on some systems, <locale.h> doesn't include <xlocale.h>; this makes sure that we get both
 #endif
 #endif


### PR DESCRIPTION
@wsnipex this should fix build error for Ubuntu 17.10.