### PR TITLE
New setting for the default keepmethod of new recording timers

### DIFF
--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v3.4.1
+- New addon setting for the keep method & default lifetime of recordings
+
 v3.4.0
 - Updated to PVR addon API v5.8.0
 

--- a/pvr.mediaportal.tvserver/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mediaportal.tvserver/resources/language/resource.language.en_gb/strings.po
@@ -66,7 +66,11 @@ msgctxt "#30011"
 msgid "Enable old series recording dialog"
 msgstr ""
 
-#empty strings from id 30012 to 30014
+msgctxt "#30012"
+msgid "Default recording lifetime"
+msgstr ""
+
+#empty strings from id 30013 to 30014
 
 msgctxt "#30015"
 msgid "Streaming method"

--- a/pvr.mediaportal.tvserver/resources/settings.xml
+++ b/pvr.mediaportal.tvserver/resources/settings.xml
@@ -16,7 +16,9 @@
     <setting id="tvgroup" type="text" label="30006" default="" />
     <setting id="radiogroup" type="text" label="30007" default="" />
     <setting id="readgenre" type="bool" label="30009" default="false" />
-	<setting id="enableoldseriesdlg" type="bool" label="30011" default="false" />
+    <setting id="enableoldseriesdlg" type="bool" label="30011" default="false" />
+    <setting id="keepmethodtype" type="enum" label="30012" lvalues="30130|30131|30132|30133" default="3" />
+    <setting id="defaultlifetime" type="slider" label="30132" option="int" range="1,1,365" default="100" visible="eq(-1,2)" />
   </category>
 
   <!-- TSReader/ffmpeg -->

--- a/src/client.h
+++ b/src/client.h
@@ -27,6 +27,7 @@
 #include "libXBMC_addon.h"
 #include "libXBMC_pvr.h"
 #include "libKODI_guilib.h"
+#include "timers.h"
 
 enum eStreamingMethod
 {
@@ -71,6 +72,8 @@ extern std::string      g_szRadioGroup;
 extern std::string      g_szSMBusername;
 extern std::string      g_szSMBpassword;
 extern eStreamingMethod g_eStreamingMethod;
+extern TvDatabase::KeepMethodType  g_KeepMethodType;
+extern int                         g_DefaultRecordingLifeTime;
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr          *PVR;

--- a/src/timers.cpp
+++ b/src/timers.cpp
@@ -662,6 +662,28 @@ void cLifeTimeValues::SetLifeTimeValues(PVR_TIMER_TYPE& timertype)
   timertype.iLifetimesSize = m_lifetimeValues.size();
   timertype.iLifetimesDefault = -MPTV_KEEP_ALWAYS; //Negative = special types, positive values is days
 
+  //select default keep method
+  switch (g_KeepMethodType)
+  {
+    case TvDatabase::UntilSpaceNeeded: //until space needed
+      timertype.iLifetimesDefault = -MPTV_KEEP_UNTIL_SPACE_NEEDED; //Negative = special types, positive values is days
+      break;
+
+    case TvDatabase::UntilWatched: //until watched
+      timertype.iLifetimesDefault = -MPTV_KEEP_UNTIL_WATCHED; //Negative = special types, positive values is days
+      break;
+
+    case TvDatabase::TillDate: //until keepdate
+      //use defaultrecordinglifetime value from settings.xml
+      timertype.iLifetimesDefault = g_DefaultRecordingLifeTime;
+      break;
+
+    case TvDatabase::Always: //forever
+    default:
+      break;
+  }
+
+
   int i = 0;
   std::vector<std::pair<int, std::string>>::iterator it;
   for (it = m_lifetimeValues.begin(); ((it != m_lifetimeValues.end()) && (i < PVR_ADDON_TIMERTYPE_VALUES_ARRAY_SIZE)); ++it, ++i)


### PR DESCRIPTION
Hey @margo.

Hope now that the feature will find its way into the official code :-)
This is the second attempt for: https://github.com/kodi-pvr/pvr.mediaportal.tvserver/issues/70

With this changes the user can set the default keepmethod of recordings.
So in my case ill set it to "until space needed" and old recordings will be deleted automatically on low space.

I have added one string (30012) to de & en languages.
How is the translation handled for other languages?

thx
pOpY