### PR TITLE
[fix] allow building with glibc 2.26 or newer (backport)

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="2.4.20"
+  version="2.4.21"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v2.4.21
+- Fixed: allow building with glibc 2.26 or newer
+
 v2.4.14
 - Fixed: #44 Active recordings not playable (multi-line description fields were not accepted)
   Requires at least TVServerKodi v1.15.0.137 (MediaPortal 1) or v1.13.100.137

--- a/src/lib/live555/liveMedia/include/Locale.hh
+++ b/src/lib/live555/liveMedia/include/Locale.hh
@@ -43,7 +43,7 @@ along with this library; if not, write to the Free Software Foundation, Inc.,
 
 #ifndef LOCALE_NOT_USED
 #include <locale.h>
-#ifndef XLOCALE_NOT_USED
+#if !defined(XLOCALE_NOT_USED) && (!defined(__GLIBC__) || !defined(__GLIBC_MINOR__) || __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 26))
 #include <xlocale.h> // because, on some systems, <locale.h> doesn't include <xlocale.h>; this makes sure that we get both
 #endif
 #endif


### PR DESCRIPTION
This should fix the Ubuntu Artful and Bionic deb builds