### PR TITLE
Update to v3.5.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,10 @@ set(MPTV_HEADERS src/Cards.h
                  src/utils.h)
 source_group("Header Files" FILES ${MPTV_HEADERS})
 if(WIN32)
-  set(MPTV_HEADERS_WINDOWS src/windows/WindowsUtils.h)
+  set(MPTV_HEADERS_WINDOWS
+    src/FileUtils.h
+    src/windows/WindowsUtils.h
+  )
   source_group("Header Files\\windows" FILES ${MPTV_HEADERS_WINDOWS})
   list(APPEND MPTV_HEADERS ${MPTV_HEADERS_WINDOWS})
 endif(WIN32)

--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="3.5.4"
+  version="3.5.5"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,7 @@
+v3.5.5
+- Fixed: Windows UWP build
+- Added: Check also C:\ProgramData\Team MediaPortal\MediaPortal TV Server\thumbs for recording thumbs in single seat mode
+
 v3.5.4
 - Remove Windows XP support
 - Don't update the Kodi connection state when trying to connect in the background thread. This prevents pop-ups every minute when the backend is down.

--- a/src/FileUtils.h
+++ b/src/FileUtils.h
@@ -27,4 +27,13 @@ namespace OS
   public:
     static bool Exists(const std::string& strFileName, long* errCode = NULL);
   };
+
+#ifdef TARGET_WINDOWS_DESKTOP
+  /**
+   * Return the location of the Program Data folder
+   * @param[in,out] programData Reference to a string that will receive the program data path
+   * @return true on success, false on failure
+   */
+  bool GetProgramData(std::string& programData);
+#endif
 };

--- a/src/pvrclient-mediaportal.h
+++ b/src/pvrclient-mediaportal.h
@@ -120,6 +120,7 @@ private:
   void SetConnectionState(PVR_CONNECTION_STATE newState);
   cRecording* GetRecordingInfo(const PVR_RECORDING& recording);
   const char* GetConnectionStateString(PVR_CONNECTION_STATE state) const;
+  void AddStreamProperty(PVR_NAMED_VALUE* properties, unsigned int* propertiesCount, std::string name, std::string value);
 
   int                     m_iCurrentChannel;
   int                     m_iCurrentCard;
@@ -146,8 +147,6 @@ private:
   int                     m_iSNR;
 
   cRecording*             m_lastSelectedRecording;
-
-  void Close();
 
   //Used for TV Server communication:
   std::string SendCommand(const char* command);

--- a/src/windows/FileUtils.cpp
+++ b/src/windows/FileUtils.cpp
@@ -22,6 +22,9 @@
 #include "p8-platform/windows/CharsetConverter.h"
 #include <string>
 #include "../utils.h"
+#ifdef TARGET_WINDOWS_DESKTOP
+#include<Shlobj.h>
+#endif
 
 namespace OS
 {
@@ -41,4 +44,24 @@ namespace OS
 
     return false;
   }
+
+#ifdef TARGET_WINDOWS_DESKTOP
+  /**
+  * Return the location of the Program Data folder
+  */
+  bool GetProgramData(std::string& programData)
+  {
+    LPWSTR wszPath = NULL;
+    if (SHGetKnownFolderPath(FOLDERID_ProgramData, 0, NULL, &wszPath) != S_OK)
+    {
+      return false;
+    }
+    std::wstring wPath = wszPath;
+    CoTaskMemFree(wszPath);
+    programData = WStringToString(wPath);
+
+    return true;
+  }
+
+#endif
 }


### PR DESCRIPTION
- Windows UWP build fix
- Add an additional search location for recording thumbs
- Set the mime type to video/mp2t (mpegts) stream to speed-up stream probing