### PR TITLE
Update to v3.5.11

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="3.5.10"
+  version="3.5.11"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,6 +1,7 @@
 v3.5.11:
 - Fixed: GetAddonCapabilities() did not explicitly set all newly added capabilities
 - Fixed: Error: "Couldn't get 'defaultrecordinglifetime' setting, falling back to '100' as default"
+- Fixed: Kodi crash during plugin load
 
 v3.5.10
 - Android: fix compiling for android with ndk-18  (credits Rechi)

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,7 @@
+v3.5.11:
+- Fixed: GetAddonCapabilities() did not explicitly set all newly added capabilities
+- Fixed: Error: "Couldn't get 'defaultrecordinglifetime' setting, falling back to '100' as default"
+
 v3.5.10
 - Android: fix compiling for android with ndk-18  (credits Rechi)
 

--- a/pvr.mediaportal.tvserver/resources/settings.xml
+++ b/pvr.mediaportal.tvserver/resources/settings.xml
@@ -18,7 +18,7 @@
     <setting id="readgenre" type="bool" label="30009" default="false" />
     <setting id="enableoldseriesdlg" type="bool" label="30011" default="false" />
     <setting id="keepmethodtype" type="enum" label="30012" lvalues="30130|30131|30132|30133" default="3" />
-    <setting id="defaultlifetime" type="slider" label="30132" option="int" range="1,1,365" default="100" visible="eq(-1,2)" />
+    <setting id="defaultrecordinglifetime" type="slider" label="30132" option="int" range="1,1,365" default="100" visible="eq(-1,2)" />
   </category>
 
   <!-- TSReader/ffmpeg -->

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -494,23 +494,30 @@ void OnPowerSavingDeactivated()
 //-----------------------------------------------------------------------------
 PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES *pCapabilities)
 {
-  KODI->Log(LOG_DEBUG, "->GetProperties()");
+  KODI->Log(LOG_DEBUG, "->GetAddonCapabilities()");
 
-  pCapabilities->bSupportsEPG                = true;
-  pCapabilities->bSupportsRecordings         = true;
+  memset(pCapabilities, 0, sizeof(PVR_ADDON_CAPABILITIES));
+
+  pCapabilities->bSupportsEPG = true;
+  pCapabilities->bSupportsEPGEdl = false;
+  pCapabilities->bSupportsTV = true;
+  pCapabilities->bSupportsRadio = g_bRadioEnabled;
+  pCapabilities->bSupportsRecordings = true;
   pCapabilities->bSupportsRecordingsUndelete = false;
-  pCapabilities->bSupportsTimers             = true;
-  pCapabilities->bSupportsTV                 = true;
-  pCapabilities->bSupportsRadio              = g_bRadioEnabled;
-  pCapabilities->bSupportsChannelGroups      = true;
-  pCapabilities->bHandlesInputStream         = true;
-  pCapabilities->bHandlesDemuxing            = false;
-  pCapabilities->bSupportsChannelScan        = false;
+  pCapabilities->bSupportsTimers = true;
+  pCapabilities->bSupportsChannelGroups = true;
+  pCapabilities->bSupportsChannelScan = false;
+  pCapabilities->bSupportsChannelSettings = false;
+  pCapabilities->bHandlesInputStream = true;
+  pCapabilities->bHandlesDemuxing = false;
   pCapabilities->bSupportsRecordingPlayCount = (g_iTVServerKodiBuild < 117) ? false : true;
   pCapabilities->bSupportsLastPlayedPosition = (g_iTVServerKodiBuild < 121) ? false : true;
+  pCapabilities->bSupportsRecordingEdl = false;
   pCapabilities->bSupportsRecordingsRename = true;
   pCapabilities->bSupportsRecordingsLifetimeChange = false;
   pCapabilities->bSupportsDescrambleInfo = false;
+  pCapabilities->bSupportsAsyncEPGTransfer = false;
+  pCapabilities->iRecordingsLifetimesSize = 0;
 
   return PVR_ERROR_NO_ERROR;
 }

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -439,7 +439,7 @@ const char* cPVRClientMediaPortal::GetBackendVersion(void)
 const char* cPVRClientMediaPortal::GetConnectionString(void)
 {
   if (m_ConnectionString.empty())
-    return nullptr;
+    return "";
 
   KODI->Log(LOG_DEBUG, "GetConnectionString: %s", m_ConnectionString.c_str());
   return m_ConnectionString.c_str();


### PR DESCRIPTION
v3.5.11:
- Fixed: GetAddonCapabilities() did not explicitly set all newly added capabilities
- Fixed: Error: "Couldn't get 'defaultrecordinglifetime' setting, falling back to '100' as default"
- Fixed: Kodi crash during plugin load