### PR TITLE
Update the plugin to v3.5.14 (Fixes for v18)

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="3.5.13"
+  version="3.5.14"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,19 @@
+v3.5.14:
+- Fixed: Delete the tsreader when tuning to a new channel failed. This fixes the first re-tune to a working channel after a failure
+- Updated: recommended TVServerKodi version to build 140
+- Recording playback: update the end time if the recording is still ongoing
+- Recording: Prevent setting a negative last played position. MediaPortal does not like this.
+- Recording: mark in-progress recording as "real-time" also on non-Windows targets
+- Fixed: various 64-bit compiler warnings
+- Fixed: Increase the command buffer size to fit the full contents of strRecordingId in DeleteRecording() and GetRecordings()
+- Fixed: tsreader: checking for < 0 on unsigned values is useless
+
+v3.5.13:
+- Translation update from Transifex
+
+v3.5.12:
+- Translation update from Transifex
+
 v3.5.11:
 - Fixed: GetAddonCapabilities() did not explicitly set all newly added capabilities
 - Fixed: Error: "Couldn't get 'defaultrecordinglifetime' setting, falling back to '100' as default"

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -433,7 +433,7 @@ bool Socket::connect ( const std::string& host, const unsigned short port )
       continue;
     }
 
-    int status = ::connect(_sd, address->ai_addr, address->ai_addrlen);
+    int status = ::connect(_sd, address->ai_addr, static_cast<int>(address->ai_addrlen));
     if (status == SOCKET_ERROR)
     {
       close();

--- a/src/lib/tsreader/DeMultiplexer.cpp
+++ b/src/lib/tsreader/DeMultiplexer.cpp
@@ -99,25 +99,25 @@ namespace MPTV
     /// and processes the raw data
     /// When a TS packet has been discovered, OnTsPacket(byte* tsPacket) gets called
     //  which in its turn deals with the packet
-    int CDeMultiplexer::ReadFromFile()
+    size_t CDeMultiplexer::ReadFromFile()
     {
         if (m_filter.IsSeeking())
             return 0;       // Ambass : to check
 
         P8PLATFORM::CLockObject lock(m_sectionRead);
         if (NULL == m_reader)
-            return false;
+            return 0;
 
         byte buffer[READ_SIZE];
-        unsigned long dwReadBytes = 0;
+        size_t dwReadBytes = 0;
 
         // if we are playing a RTSP stream
         if (m_reader->IsBuffer())
         {
             // and, the current buffer holds data
-            int nBytesToRead = m_reader->HasData();
+            size_t nBytesToRead = m_reader->HasData();
 
-            if (nBytesToRead > (int) sizeof(buffer))
+            if (nBytesToRead > sizeof(buffer))
             {
                 nBytesToRead = sizeof(buffer);
             }
@@ -130,13 +130,13 @@ namespace MPTV
             if (nBytesToRead)
             {
               // then read raw data from the buffer
-              if (SUCCEEDED(m_reader->Read(buffer, nBytesToRead, (unsigned long*)&dwReadBytes)))
+              if (SUCCEEDED(m_reader->Read(buffer, nBytesToRead, &dwReadBytes)))
               {
                 if (dwReadBytes > 0)
                 {
                   // yes, then process the raw data
                   //result=true;
-                  OnRawData(buffer, (int)dwReadBytes);
+                  OnRawData(buffer, dwReadBytes);
                   m_LastDataFromRtsp = GetTickCount64();
                 }
               }
@@ -165,7 +165,7 @@ namespace MPTV
         {
             // playing a local file.
             // read raw data from the file
-            if (SUCCEEDED(m_reader->Read(buffer, sizeof(buffer), (unsigned long*)&dwReadBytes)))
+            if (SUCCEEDED(m_reader->Read(buffer, sizeof(buffer), &dwReadBytes)))
             {
                 if ((m_filter.IsTimeShifting()) && (dwReadBytes < sizeof(buffer)))
                 {

--- a/src/lib/tsreader/DeMultiplexer.h
+++ b/src/lib/tsreader/DeMultiplexer.h
@@ -55,7 +55,7 @@ namespace MPTV
         void       OnNewChannel(CChannelInfo& info);
         void       SetFileReader(FileReader* reader);
         void RequestNewPat(void);
-        int ReadFromFile();
+        size_t ReadFromFile();
 
     private:
         unsigned long long m_LastDataFromRtsp;

--- a/src/lib/tsreader/FileReader.cpp
+++ b/src/lib/tsreader/FileReader.cpp
@@ -202,9 +202,16 @@ namespace MPTV
     }
 
 
-    long FileReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
+    long FileReader::Read(unsigned char* pbData, size_t lDataLength, size_t *dwReadBytes)
     {
-        *dwReadBytes = KODI->ReadFile(m_hFile, (void*)pbData, lDataLength);//Read file data into buffer
+		ssize_t read_bytes = KODI->ReadFile(m_hFile, (void*)pbData, lDataLength);//Read file data into buffer
+		if (read_bytes < 0)
+		{
+			TSDEBUG(LOG_DEBUG, "%s: ReadFile function failed.", __FUNCTION__);
+			*dwReadBytes = 0;
+			return S_FALSE;
+		}
+		*dwReadBytes = static_cast<size_t>(read_bytes);
         TSDEBUG(LOG_DEBUG, "%s: requested read length %d actually read %d.", __FUNCTION__, lDataLength, *dwReadBytes);
 
         if (*dwReadBytes < lDataLength)

--- a/src/lib/tsreader/FileReader.h
+++ b/src/lib/tsreader/FileReader.h
@@ -50,14 +50,14 @@ namespace MPTV
         virtual long OpenFile(const std::string& fileName);
         virtual long OpenFile();
         virtual long CloseFile();
-        virtual long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
+        virtual long Read(unsigned char* pbData, size_t lDataLength, size_t *dwReadBytes);
         virtual bool IsFileInvalid();
         virtual int64_t SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod);
         virtual int64_t GetFilePointer();
         virtual int64_t GetFileSize();
         virtual bool IsBuffer() { return false; };
         virtual int64_t OnChannelChange(void);
-        virtual int HasData(){ return 0; };
+        virtual size_t HasData(){ return 0; };
 
     protected:
         void*       m_hFile;               // Handle to file for streaming

--- a/src/lib/tsreader/MemoryBuffer.cpp
+++ b/src/lib/tsreader/MemoryBuffer.cpp
@@ -161,7 +161,7 @@ size_t CMemoryBuffer::ReadFromBuffer(unsigned char *pbData, size_t lDataLength)
 
 long CMemoryBuffer::PutBuffer(unsigned char *pbData, size_t lDataLength)
 {
-  if (lDataLength <= 0 || pbData == NULL) return E_FAIL;
+  if (lDataLength == 0 || pbData == NULL) return E_FAIL;
 
   BufferItem* item = new BufferItem();
   item->nOffset = 0;

--- a/src/lib/tsreader/MemoryReader.cpp
+++ b/src/lib/tsreader/MemoryReader.cpp
@@ -42,9 +42,9 @@ namespace MPTV
     {
     }
 
-    long CMemoryReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
+    long CMemoryReader::Read(unsigned char* pbData, unsigned long lDataLength, size_t *dwReadBytes)
     {
-        *dwReadBytes = m_buffer.ReadFromBuffer(pbData,lDataLength);
+        *dwReadBytes = m_buffer.ReadFromBuffer(pbData, lDataLength);
         if ((*dwReadBytes) == 0)
             return S_FALSE;
         return S_OK;
@@ -55,7 +55,7 @@ namespace MPTV
         return 0;
     }
 
-    int CMemoryReader::HasData()
+    size_t CMemoryReader::HasData()
     {
         return (m_buffer.Size());
     }

--- a/src/lib/tsreader/MemoryReader.cpp
+++ b/src/lib/tsreader/MemoryReader.cpp
@@ -45,7 +45,7 @@ namespace MPTV
     long CMemoryReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
     {
         *dwReadBytes = m_buffer.ReadFromBuffer(pbData,lDataLength);
-        if ((*dwReadBytes) <=0)
+        if ((*dwReadBytes) == 0)
             return S_FALSE;
         return S_OK;
     }

--- a/src/lib/tsreader/MemoryReader.h
+++ b/src/lib/tsreader/MemoryReader.h
@@ -40,11 +40,11 @@ namespace MPTV
       public:
         CMemoryReader(CMemoryBuffer& buffer);
         virtual ~CMemoryReader(void);
-        long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
+        long Read(unsigned char* pbData, unsigned long lDataLength, size_t *dwReadBytes);
         unsigned long setFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod);
         bool IsBuffer() { return true; };
         long CloseFile() { return S_OK; };
-        int HasData();
+        size_t HasData();
 
       private:
         CMemoryBuffer& m_buffer;

--- a/src/lib/tsreader/MultiFileReader.cpp
+++ b/src/lib/tsreader/MultiFileReader.cpp
@@ -241,7 +241,7 @@ namespace MPTV
         return m_currentPosition;
     }
 
-    long MultiFileReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
+    long MultiFileReader::Read(unsigned char* pbData, size_t lDataLength, size_t *dwReadBytes)
     {
         // If the file has already been closed, don't continue
         if (m_TSBufferFile.IsFileInvalid())
@@ -306,14 +306,14 @@ namespace MPTV
                 }
             }
 
-            unsigned long bytesRead = 0;
+            size_t bytesRead = 0;
             long hr;
 
             int64_t bytesToRead = file->length - seekPosition;
             if ((int64_t)lDataLength > bytesToRead)
             {
                 // KODI->Log(LOG_DEBUG, "%s: datalength %lu bytesToRead %lli.", __FUNCTION__, lDataLength, bytesToRead);
-                hr = m_TSFile.Read(pbData, (unsigned long)bytesToRead, &bytesRead);
+                hr = m_TSFile.Read(pbData, (size_t)bytesToRead, &bytesRead);
                 if (FAILED(hr))
                 {
                     KODI->Log(LOG_ERROR, "READ FAILED1");
@@ -321,7 +321,7 @@ namespace MPTV
                 }
                 m_currentPosition += bytesToRead;
 
-                hr = this->Read(pbData + bytesToRead, lDataLength - (unsigned long)bytesToRead, dwReadBytes);
+                hr = this->Read(pbData + bytesToRead, lDataLength - (size_t)bytesToRead, dwReadBytes);
                 if (FAILED(hr))
                 {
                     KODI->Log(LOG_ERROR, "READ FAILED2");
@@ -357,7 +357,7 @@ namespace MPTV
             return S_FALSE;
         }
 
-        unsigned long bytesRead;
+        size_t bytesRead;
         MultiFileReaderFile *file;
 
         int64_t currentPosition;
@@ -388,7 +388,7 @@ namespace MPTV
 
             m_TSBufferFile.SetFilePointer(0, FILE_BEGIN);
 
-            uint32_t readLength = sizeof(currentPosition) + sizeof(filesAdded) + sizeof(filesRemoved);
+            size_t readLength = sizeof(currentPosition) + sizeof(filesAdded) + sizeof(filesRemoved);
             unsigned char* readBuffer = new unsigned char[readLength];
 
             long result = m_TSBufferFile.Read(readBuffer, readLength, &bytesRead);
@@ -519,7 +519,7 @@ namespace MPTV
             std::vector<std::string> filenames;
 
             Wchar_t* pwCurrFile = pBuffer;    //Get a pointer to the first wchar filename string in pBuffer
-            long length = WcsLen(pwCurrFile);
+            size_t length = WcsLen(pwCurrFile);
 
             //KODI->Log(LOG_DEBUG, "%s: WcsLen(%d), sizeof(Wchar_t) == %d sizeof(wchar_t) == %d.", __FUNCTION__, length, sizeof(Wchar_t), sizeof(wchar_t));
 

--- a/src/lib/tsreader/MultiFileReader.h
+++ b/src/lib/tsreader/MultiFileReader.h
@@ -58,7 +58,7 @@ namespace MPTV
         virtual long OpenFile();
         virtual long OpenFile(const std::string& fileName);
         virtual long CloseFile();
-        virtual long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
+        virtual long Read(unsigned char* pbData, size_t lDataLength, size_t *dwReadBytes);
 
         virtual bool IsFileInvalid();
 

--- a/src/lib/tsreader/PacketSync.cpp
+++ b/src/lib/tsreader/PacketSync.cpp
@@ -41,9 +41,9 @@ namespace MPTV
 
     // Ambass : Now, need to have 2 consecutive TS_PACKET_SYNC to try avoiding bad synchronisation.  
     //          In case of data flow change ( Seek, tv Zap .... ) Reset() should be called first to flush buffer.
-    void CPacketSync::OnRawData(byte* pData, int nDataLen)
+    void CPacketSync::OnRawData(byte* pData, size_t nDataLen)
     {
-        int syncOffset = 0;
+        size_t syncOffset = 0;
         if (m_tempBufferPos > 0)
         {
             if (pData[TS_PACKET_LEN - m_tempBufferPos] == TS_PACKET_SYNC)

--- a/src/lib/tsreader/PacketSync.h
+++ b/src/lib/tsreader/PacketSync.h
@@ -35,12 +35,12 @@ namespace MPTV
 
     public:
         virtual ~CPacketSync(void);
-        void OnRawData(byte* pData, int nDataLen);
+        void OnRawData(byte* pData, size_t nDataLen);
         virtual void OnTsPacket(byte* tsPacket);
         void Reset(void);
 
     private:
         byte  m_tempBuffer[200];
-        int   m_tempBufferPos;
+        ssize_t   m_tempBufferPos;
     };
 }

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -302,7 +302,7 @@ namespace MPTV
             return m_fileReader->Read(pbData, lDataLength, dwReadBytes);
         }
 
-        dwReadBytes = 0;
+        *dwReadBytes = 0;
         return S_FALSE;
     }
 

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -365,12 +365,19 @@ namespace MPTV
                 }
                 else
                 {
+                  if (timeShiftBufferPos < 0)
+                  {
+                    pos_after = m_fileReader->SetFilePointer(0LL, FILE_BEGIN);
+                  }
+                  else
+                  {
                     pos_after = m_fileReader->SetFilePointer(0LL, FILE_END);
                     if ((timeShiftBufferPos > 0) && (pos_after > timeShiftBufferPos))
                     {
-                        /* Move backward */
-                        pos_after = fileReader->SetFilePointer((timeShiftBufferPos - pos_after), FILE_CURRENT);
+                      /* Move backward */
+                      pos_after = fileReader->SetFilePointer((timeShiftBufferPos - pos_after), FILE_CURRENT);
                     }
+                  }
                 }
 
                 m_demultiplexer.RequestNewPat();

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -208,7 +208,7 @@ namespace MPTV
             Close();
 
         // check file type
-        int length = m_fileName.length();
+        size_t length = m_fileName.length();
 
         if ((length > 7) && (strnicmp(m_fileName.c_str(), "rtsp://", 7) == 0))
         {
@@ -295,7 +295,7 @@ namespace MPTV
         return S_OK;
     }
 
-    long CTsReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
+    long CTsReader::Read(unsigned char* pbData, size_t lDataLength, size_t *dwReadBytes)
     {
         if (m_fileReader)
         {
@@ -393,7 +393,7 @@ namespace MPTV
     {
         std::string tmp = directory;
 
-#ifdef TARGET_WINDOWS
+#ifdef TARGET_WINDOWS_DESKTOP
         if (tmp.find("smb://") != string::npos)
         {
           // Convert XBMC smb share name back to a real windows network share...

--- a/src/lib/tsreader/TSReader.h
+++ b/src/lib/tsreader/TSReader.h
@@ -52,7 +52,7 @@ namespace MPTV
         CTsReader();
         ~CTsReader(void);
         long Open(const char* pszFileName);
-        long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
+        long Read(unsigned char* pbData, size_t lDataLength, size_t *dwReadBytes);
         void Close();
         int64_t SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod);
         int64_t GetFileSize();

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -2215,11 +2215,11 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordingStreamProperties(const PVR_RECORDIN
   {
     AddStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_STREAMURL, myrecording->Stream());
   }
-#ifdef TARGET_WINDOWS_DESKTOP
   else if (!g_bUseRTSP)
   {
     if (myrecording->IsRecording() == false)
     {
+#ifdef TARGET_WINDOWS_DESKTOP
       if (OS::CFile::Exists(myrecording->FilePath()))
       {
         std::string recordingUri(ToKodiPath(myrecording->FilePath()));
@@ -2227,6 +2227,7 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordingStreamProperties(const PVR_RECORDIN
         // Direct file playback by Kodi (without involving the addon)
         AddStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_STREAMURL, recordingUri.c_str());
       }
+#endif
     }
     else
     {
@@ -2234,7 +2235,6 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordingStreamProperties(const PVR_RECORDIN
       AddStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_ISREALTIMESTREAM, "true");
     }
   }
-#endif
 
   return PVR_ERROR_NO_ERROR;
 }

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -1856,8 +1856,8 @@ bool cPVRClientMediaPortal::OpenLiveStream(const PVR_CHANNEL &channelinfo)
 
 int cPVRClientMediaPortal::ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize)
 {
-  unsigned long read_wanted = iBufferSize;
-  unsigned long read_done   = 0;
+  size_t read_wanted = iBufferSize;
+  size_t read_done   = 0;
   static int read_timeouts  = 0;
   unsigned char* bufptr = pBuffer;
 
@@ -1874,7 +1874,7 @@ int cPVRClientMediaPortal::ReadLiveStream(unsigned char *pBuffer, unsigned int i
     return -1;
   }
 
-  while (read_done < (unsigned long) iBufferSize)
+  while (read_done < static_cast<size_t>(iBufferSize))
   {
     read_wanted = iBufferSize - read_done;
 
@@ -1882,11 +1882,11 @@ int cPVRClientMediaPortal::ReadLiveStream(unsigned char *pBuffer, unsigned int i
     {
       usleep(20000);
       read_timeouts++;
-      return read_wanted;
+      return static_cast<int>(read_wanted);
     }
     read_done += read_wanted;
 
-    if ( read_done < (unsigned long) iBufferSize )
+    if ( read_done < static_cast<size_t>(iBufferSize) )
     {
       if (read_timeouts > 200)
       {
@@ -1900,7 +1900,7 @@ int cPVRClientMediaPortal::ReadLiveStream(unsigned char *pBuffer, unsigned int i
         //if read_done == 0 then check if the backend is still timeshifting,
         //or retrieve the reason why the timeshifting was stopped/failed...
 
-        return read_done;
+        return static_cast<int>(read_done);
       }
       bufptr += read_wanted;
       read_timeouts++;
@@ -1909,7 +1909,7 @@ int cPVRClientMediaPortal::ReadLiveStream(unsigned char *pBuffer, unsigned int i
   }
   read_timeouts = 0;
 
-  return read_done;
+  return static_cast<int>(read_done);
 }
 
 void cPVRClientMediaPortal::CloseLiveStream(void)
@@ -2143,14 +2143,14 @@ void cPVRClientMediaPortal::CloseRecordedStream(void)
 
 int cPVRClientMediaPortal::ReadRecordedStream(unsigned char *pBuffer, unsigned int iBufferSize)
 {
-  unsigned long read_wanted = iBufferSize;
-  unsigned long read_done   = 0;
+  size_t read_wanted = static_cast<size_t>(iBufferSize);
+  size_t read_done   = 0;
   unsigned char* bufptr = pBuffer;
 
   if (g_eStreamingMethod == ffmpeg)
     return -1;
 
-  while (read_done < (unsigned long) iBufferSize)
+  while (read_done < static_cast<size_t>(iBufferSize))
   {
     read_wanted = iBufferSize - read_done;
     if (!m_tsreader)
@@ -2159,18 +2159,18 @@ int cPVRClientMediaPortal::ReadRecordedStream(unsigned char *pBuffer, unsigned i
     if (m_tsreader->Read(bufptr, read_wanted, &read_wanted) > 0)
     {
       usleep(20000);
-      return read_wanted;
+      return static_cast<int>(read_wanted);
     }
     read_done += read_wanted;
 
-    if ( read_done < (unsigned long) iBufferSize )
+    if ( read_done < static_cast<size_t>(iBufferSize) )
     {
       bufptr += read_wanted;
       usleep(20000);
     }
   }
 
-  return read_done;
+  return static_cast<int>(read_done);
 }
 
 long long cPVRClientMediaPortal::SeekRecordedStream(long long iPosition, int iWhence)

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -139,7 +139,7 @@ string cPVRClientMediaPortal::SendCommand(const string& command)
 }
 
 
-bool cPVRClientMediaPortal::SendCommand2(string command, vector<string>& lines)
+bool cPVRClientMediaPortal::SendCommand2(const string& command, vector<string>& lines)
 {
   string result = SendCommand(command);
 
@@ -1084,10 +1084,10 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordings(ADDON_HANDLE handle)
         PVR_STRCLR(tag.strDirectory);
       }
 
-      std::string recordingUri(ToKodiPath(recording.FilePath()));
       PVR_STRCLR(tag.strThumbnailPath);
 
 #ifdef TARGET_WINDOWS_DESKTOP
+      std::string recordingUri(ToKodiPath(recording.FilePath()));
       if (g_bUseRTSP == false)
       {
         /* Recording thumbnail */
@@ -1149,13 +1149,13 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordings(ADDON_HANDLE handle)
 
 PVR_ERROR cPVRClientMediaPortal::DeleteRecording(const PVR_RECORDING &recording)
 {
-  char            command[256];
+  char            command[1200];
   string          result;
 
   if (!IsUp())
     return PVR_ERROR_SERVER_ERROR;
 
-  snprintf(command, 256, "DeleteRecordedTV:%s\n", recording.strRecordingId);
+  snprintf(command, 1200, "DeleteRecordedTV:%s\n", recording.strRecordingId);
 
   result = SendCommand(command);
 
@@ -1175,13 +1175,13 @@ PVR_ERROR cPVRClientMediaPortal::DeleteRecording(const PVR_RECORDING &recording)
 
 PVR_ERROR cPVRClientMediaPortal::RenameRecording(const PVR_RECORDING &recording)
 {
-  char           command[512];
+  char           command[1200];
   string         result;
 
   if (!IsUp())
     return PVR_ERROR_SERVER_ERROR;
 
-  snprintf(command, 512, "UpdateRecording:%s|%s\n",
+  snprintf(command, 1200, "UpdateRecording:%s|%s\n",
     recording.strRecordingId,
     uri::encode(uri::PATH_TRAITS, recording.strTitle).c_str());
 
@@ -1772,7 +1772,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const PVR_CHANNEL &channelinfo)
 
     if (g_eStreamingMethod == TSReader)
     {
-      if (g_eStreamingMethod == TSReader && m_tsreader != NULL)
+      if (m_tsreader != NULL)
       {
         bool bReturn = false;
 
@@ -2258,7 +2258,7 @@ PVR_ERROR cPVRClientMediaPortal::GetChannelStreamProperties(const PVR_CHANNEL* c
       {
         KODI->Log(LOG_DEBUG, "GetChannelStreamProperties (ffmpeg) for uid=%i is '%s'", channel->iUniqueId,
                   m_PlaybackURL.c_str());
-        AddStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_STREAMURL, m_PlaybackURL.c_str());
+        AddStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_STREAMURL, m_PlaybackURL);
         AddStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_ISREALTIMESTREAM, "true");
         AddStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_MIMETYPE, "video/mp2t");
         return PVR_ERROR_NO_ERROR;

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -48,8 +48,8 @@ int g_iTVServerKodiBuild = 0;
 /* TVServerKodi plugin supported versions */
 #define TVSERVERKODI_MIN_VERSION_STRING         "1.1.7.107"
 #define TVSERVERKODI_MIN_VERSION_BUILD          107
-#define TVSERVERKODI_RECOMMENDED_VERSION_STRING "1.2.3.122 till 1.15.0.136"
-#define TVSERVERKODI_RECOMMENDED_VERSION_BUILD  136
+#define TVSERVERKODI_RECOMMENDED_VERSION_STRING "1.2.3.122 till 1.20.0.140"
+#define TVSERVERKODI_RECOMMENDED_VERSION_BUILD  140
 
 /************************************************************/
 /** Class interface */

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -2423,8 +2423,16 @@ PVR_ERROR cPVRClientMediaPortal::GetStreamTimes(PVR_STREAM_TIMES* stream_times)
     // Warning: documentation in xbmc_pvr_types.h is wrong. pts values are not in seconds.
     stream_times->startTime = 0; // seconds
     stream_times->ptsStart = 0;  // Unit must match Kodi's internal m_clock.GetClock() which is in useconds
-    stream_times->ptsBegin = 0;  // useconds
-    stream_times->ptsEnd = ((int64_t) m_lastSelectedRecording->Duration()) * DVD_TIME_BASE; //useconds
+    if (m_lastSelectedRecording->IsRecording())
+    {
+      stream_times->ptsBegin = m_tsreader->GetPtsBegin();  // useconds
+      stream_times->ptsEnd = m_tsreader->GetPtsEnd();
+    }
+    else
+    {
+       stream_times->ptsBegin = 0;  // useconds
+       stream_times->ptsEnd = ((int64_t)m_lastSelectedRecording->Duration()) * DVD_TIME_BASE; //useconds
+    }
     return PVR_ERROR_NO_ERROR;
   }
   else if (m_bTimeShiftStarted)

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -2054,33 +2054,6 @@ bool cPVRClientMediaPortal::OpenRecordedStream(const PVR_RECORDING &recording)
 
   std::string recfile = "";
 
-#if 0
-  // TVServerKodi v1.1.0.90 or higher
-  string         result;
-  char           command[256];
-
-  //if(g_bUseRecordingsDir)
-  if(!g_bUseRTSP)
-    snprintf(command, 256, "GetRecordingInfo:%s|False\n", recording.strRecordingId);
-  else
-    snprintf(command, 256, "GetRecordingInfo:%s|True\n", recording.strRecordingId);
-  result = SendCommand(command);
-
-  if (result.empty())
-  {
-    KODI->Log(LOG_ERROR, "Backend command '%s' returned a zero-length answer.", command);
-    return false;
-  }
-
-  cRecording myrecording;
-  if (!myrecording.ParseLine(result))
-  {
-    KODI->Log(LOG_ERROR, "Parsing result from '%s' command failed. Result='%s'.", command, result.c_str());
-    return false;
-  }
-
-  KODI->Log(LOG_NOTICE, "RECORDING: %s", result.c_str() );
-#endif
   cRecording* myrecording = GetRecordingInfo(recording);
 
   if (!myrecording)
@@ -2427,16 +2400,8 @@ PVR_ERROR cPVRClientMediaPortal::GetStreamTimes(PVR_STREAM_TIMES* stream_times)
     // Warning: documentation in xbmc_pvr_types.h is wrong. pts values are not in seconds.
     stream_times->startTime = 0; // seconds
     stream_times->ptsStart = 0;  // Unit must match Kodi's internal m_clock.GetClock() which is in useconds
-    if (m_lastSelectedRecording->IsRecording())
-    {
-      stream_times->ptsBegin = m_tsreader->GetPtsBegin();  // useconds
-      stream_times->ptsEnd = m_tsreader->GetPtsEnd();
-    }
-    else
-    {
-       stream_times->ptsBegin = 0;  // useconds
-       stream_times->ptsEnd = ((int64_t)m_lastSelectedRecording->Duration()) * DVD_TIME_BASE; //useconds
-    }
+    stream_times->ptsBegin = 0;  // useconds
+    stream_times->ptsEnd = ((int64_t)m_lastSelectedRecording->Duration()) * DVD_TIME_BASE; //useconds
     return PVR_ERROR_NO_ERROR;
   }
   else if (m_bTimeShiftStarted)

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -1726,6 +1726,10 @@ bool cPVRClientMediaPortal::OpenLiveStream(const PVR_CHANNEL &channelinfo)
       }
     }
     m_iCurrentChannel = -1;
+    if (m_tsreader != nullptr)
+    {
+      SAFE_DELETE(m_tsreader);
+    }
     return false;
   }
   else

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -1239,6 +1239,11 @@ PVR_ERROR cPVRClientMediaPortal::SetRecordingLastPlayedPosition(const PVR_RECORD
   char           command[512];
   string         result;
 
+  if (lastplayedposition < 0)
+  {
+    lastplayedposition = 0;
+  }
+
   snprintf(command, 512, "SetRecordingStopTime:%i|%i\n", atoi(recording.strRecordingId), lastplayedposition);
 
   result = SendCommand(command);

--- a/src/pvrclient-mediaportal.h
+++ b/src/pvrclient-mediaportal.h
@@ -151,5 +151,5 @@ private:
   //Used for TV Server communication:
   std::string SendCommand(const char* command);
   std::string SendCommand(const std::string& command);
-  bool SendCommand2(std::string command, std::vector<std::string>& lines);
+  bool SendCommand2(const std::string& command, std::vector<std::string>& lines);
 };

--- a/src/recordings.cpp
+++ b/src/recordings.cpp
@@ -299,7 +299,23 @@ time_t cRecording::StartTime(void) const
 
 int cRecording::Duration(void) const
 {
-  return m_duration;
+  if (m_isRecording)
+  {
+    MPTV::CDateTime endTime = MPTV::CDateTime::Now();
+    int diff = endTime - m_startTime - 10;
+    if (diff > 0)
+    {
+      return diff;
+    }
+    else
+    {
+      return 0;
+    }
+  }
+  else
+  {
+    return m_duration;
+  }
 }
 
 int cRecording::GetSeriesNumber(void) const

--- a/src/timers.cpp
+++ b/src/timers.cpp
@@ -659,7 +659,7 @@ cLifeTimeValues::cLifeTimeValues()
 
 void cLifeTimeValues::SetLifeTimeValues(PVR_TIMER_TYPE& timertype)
 {
-  timertype.iLifetimesSize = m_lifetimeValues.size();
+  timertype.iLifetimesSize = static_cast<unsigned int>(m_lifetimeValues.size());
   timertype.iLifetimesDefault = -MPTV_KEEP_ALWAYS; //Negative = special types, positive values is days
 
   //select default keep method


### PR DESCRIPTION
v3.5.14:
- Fixed: Delete the tsreader when tuning to a new channel failed. This fixes the first re-tune to a working channel after a failure
- Updated: recommended TVServerKodi version to build 140
- Recording playback: update the end time if the recording is still ongoing
- Recording: Prevent setting a negative last played position. MediaPortal does not like this.
- Recording: mark in-progress recording as "real-time" also on non-Windows targets
- Fixed: various 64-bit compiler warnings
- Fixed: Increase the command buffer size to fit the full contents of strRecordingId in DeleteRecording() and GetRecordings()
- Fixed: tsreader: checking for < 0 on unsigned values is useless