### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(TinyXML REQUIRED)
 
@@ -21,8 +20,7 @@ set(LIVE555_INCLUDE_DIR
 
 set(LIVE555_DEFINES -DLIVE555 -D_WINSOCK_DEPRECATED_NO_WARNINGS -DSOCKLEN_T=socklen_t -DBSD=1)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${p8-platform_INCLUDE_DIRS}
+include_directories(${p8-platform_INCLUDE_DIRS}
                     ${TINYXML_INCLUDE_DIR}
                     ${KODI_INCLUDE_DIR}
                     ${PROJECT_SOURCE_DIR}/src

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-mediaportal-tvserver
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml-dev,
-               libkodiplatform-dev (>= 16.0.0), kodi-addon-dev
+               libp8-platform-dev, kodi-addon-dev
 Standards-Version: 3.9.4
 Section: libs
 Homepage: http://www.scintilla.utwente.nl/~marcelg/kodi/


### PR DESCRIPTION
The pvr.mediaportal.tvserver binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.