### PR TITLE
Update to v3.5.18 (Leia)

### DIFF
--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,6 +1,6 @@
 v3.5.18:
 - Fixed: TSReader: reset the timeshift start time after a successful channel switch
-
+- Fixed: radio webstream support (was broken since Kodi v18 streaming API changes)
 v3.5.17:
 - Added: GetStreamReadChunkSize support (Refs #92)
 - Fixed: TSReader (RTSP): pause hangs Kodi

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v3.5.18:
+- Fixed: TSReader: reset the timeshift start time after a successful channel switch
+
 v3.5.17:
 - Added: GetStreamReadChunkSize support (Refs #92)
 - Fixed: TSReader (RTSP): pause hangs Kodi

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -388,6 +388,11 @@ namespace MPTV
 
                 KODI->Log(LOG_DEBUG, "%s:: move from %I64d to %I64d tsbufpos  %I64d", __FUNCTION__, pos_before, pos_after, timeShiftBufferPos);
                 usleep(100000);
+
+                // Set the stream start times to this new channel
+                time(&m_startTime);
+                m_startTickCount = GetTickCount64();
+
                 return true;
             }
             return false;

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -82,6 +82,7 @@ cPVRClientMediaPortal::~cPVRClientMediaPortal()
 {
   KODI->Log(LOG_DEBUG, "->~cPVRClientMediaPortal()");
   Disconnect();
+
   SAFE_DELETE(Timer::lifetimeValues);
   SAFE_DELETE(m_tcpclient);
   SAFE_DELETE(m_genretable);
@@ -741,7 +742,7 @@ PVR_ERROR cPVRClientMediaPortal::GetChannels(ADDON_HANDLE handle, bool bRadio)
     {
       // Cache this channel in our local uid-channel list
       // This cache is used for the GUIDialogRecordSettings
-      m_channelNames[channel.UID()] = channel.Name();
+      m_channels[channel.UID()] = channel;
 
       // Prepare the PVR_CHANNEL struct to transfer this channel to Kodi
       tag.iUniqueId = channel.UID();
@@ -1517,7 +1518,7 @@ PVR_ERROR cPVRClientMediaPortal::AddTimer(const PVR_TIMER &timerinfo)
     std::string strChannelName;
     if (timerinfo.iClientChannelUid >= 0)
     {
-      strChannelName = m_channelNames[timerinfo.iClientChannelUid];
+      strChannelName = m_channels[timerinfo.iClientChannelUid].Name();
     }
     CGUIDialogRecordSettings dlgRecSettings( timerinfo, timer, strChannelName);
 
@@ -2231,7 +2232,33 @@ PVR_ERROR cPVRClientMediaPortal::GetChannelStreamProperties(const PVR_CHANNEL* c
                                                             PVR_NAMED_VALUE* properties,
                                                             unsigned int* iPropertiesCount)
 {
+  if ((channel == nullptr) || (properties == nullptr))
+  {
+    return PVR_ERROR_FAILED;
+  }
+
   *iPropertiesCount = 0;
+
+  // Is this a webstream?
+  try
+  {
+    cChannel& selectedChannel = m_channels.at(channel->iUniqueId);
+
+    if (selectedChannel.IsWebstream())
+    {
+      KODI->Log(LOG_DEBUG, "GetChannelStreamProperties (webstream) for uid=%i is '%s'",
+                channel->iUniqueId, selectedChannel.URL());
+      AddStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_STREAMURL,
+                        selectedChannel.URL());
+      AddStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_ISREALTIMESTREAM, "true");
+      return PVR_ERROR_NO_ERROR;
+    }
+  }
+  catch (const std::out_of_range& oor)
+  {
+    // channel not found in our plugin channel cache
+  }
+
   if (g_eStreamingMethod == ffmpeg)
   {
     // GetChannelStreamProperties is called before OpenLiveStream by Kodi, so we should already open the stream here...

--- a/src/pvrclient-mediaportal.h
+++ b/src/pvrclient-mediaportal.h
@@ -27,6 +27,7 @@
 #include "Socket.h"
 #include "Cards.h"
 #include "epg.h"
+#include "channels.h"
 #include "p8-platform/threads/mutex.h"
 #include "p8-platform/threads/threads.h"
 
@@ -144,7 +145,7 @@ private:
   P8PLATFORM::CMutex      m_connectionMutex;
   int64_t                 m_iLastRecordingUpdate;
   MPTV::CTsReader*        m_tsreader;
-  std::map<int,std::string> m_channelNames;
+  std::map<int,cChannel>  m_channels;
   int                     m_signalStateCounter;
   int                     m_iSignal;
   int                     m_iSNR;


### PR DESCRIPTION
v3.5.18:
- Fixed: TSReader: reset the timeshift start time after a successful channel switch
- Fixed: radio webstream support (was broken since Kodi v18 streaming API changes)
