### PR TITLE
Update to v4.0.1 (Matrix)

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="4.0.0"
+  version="4.0.1"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,4 +1,5 @@
 v4.0.1
+- Fixed: TSReader: reset the timeshift start time after a successful channel switch
 - Fixed: radio webstream support (was broken since Kodi v18 streaming API changes)
 
 v4.0.0

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v4.0.1
+- Fixed: radio webstream support (was broken since Kodi v18 streaming API changes)
+
 v4.0.0
 - Update to PVR addon API v6.0.0
 

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -388,6 +388,11 @@ namespace MPTV
 
                 KODI->Log(LOG_DEBUG, "%s:: move from %I64d to %I64d tsbufpos  %I64d", __FUNCTION__, pos_before, pos_after, timeShiftBufferPos);
                 usleep(100000);
+
+                // Set the stream start times to this new channel
+                time(&m_startTime);
+                m_startTickCount = GetTickCount64();
+
                 return true;
             }
             return false;

--- a/src/pvrclient-mediaportal.h
+++ b/src/pvrclient-mediaportal.h
@@ -27,6 +27,7 @@
 #include "Socket.h"
 #include "Cards.h"
 #include "epg.h"
+#include "channels.h"
 #include "p8-platform/threads/mutex.h"
 #include "p8-platform/threads/threads.h"
 
@@ -144,7 +145,7 @@ private:
   P8PLATFORM::CMutex      m_connectionMutex;
   int64_t                 m_iLastRecordingUpdate;
   MPTV::CTsReader*        m_tsreader;
-  std::map<int,std::string> m_channelNames;
+  std::map<int,cChannel>  m_channels;
   int                     m_signalStateCounter;
   int                     m_iSignal;
   int                     m_iSNR;


### PR DESCRIPTION
v4.0.1
- Fixed: TSReader: reset the timeshift start time after a successful channel switch
- Fixed: radio webstream support (was broken since Kodi v18 streaming API changes)