### PR TITLE
[pvr.mediaportal.tvserver] Update to 4.1.0

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="4.0.1"
+  version="4.1.0"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v4.1.0
+- Update to GUI addon API v5.14.0
+
 v4.0.1
 - Fixed: TSReader: reset the timeshift start time after a successful channel switch
 - Fixed: radio webstream support (was broken since Kodi v18 streaming API changes)


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required