### PR TITLE
Recompile for 6.1.0 PVR Addon API compatibility

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="4.1.1"
+  version="4.2.0"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v4.2.0:
+- Update: Recompile for 6.1.0 PVR Addon API compatibility
+
 v4.1.1:
 - Update: Build system version
 - Fixed: Package check for JsonCpp


### PR DESCRIPTION
v4.2.0:
- Update: Recompile for 6.1.0 PVR Addon API compatibility