### PR TITLE
Remove p8-platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ env:
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: bionic
       sudo: required
       compiler: gcc
     - os: linux
-      dist: xenial
+      dist: bionic
       sudo: required
       compiler: clang
     - os: linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(pvr.mediaportal.tvserver)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
-find_package(p8-platform REQUIRED)
 find_package(TinyXML REQUIRED)
 
 set(LIVE555_INCLUDE_DIR
@@ -17,8 +16,7 @@ set(LIVE555_INCLUDE_DIR
 
 set(LIVE555_DEFINES -DLIVE555 -D_WINSOCK_DEPRECATED_NO_WARNINGS -DSOCKLEN_T=socklen_t -DBSD=1)
 
-include_directories(${p8-platform_INCLUDE_DIRS}
-                    ${TINYXML_INCLUDE_DIR}
+include_directories(${TINYXML_INCLUDE_DIR}
                     ${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
                     ${PROJECT_SOURCE_DIR}/src
                     ${PROJECT_BINARY_DIR}
@@ -229,8 +227,7 @@ source_group("Header Files\\lib\\live555" FILES ${LIVE555_HEADERS})
 # Make sure that CMake adds all files to the MSVC project
 list(APPEND MPTV_SOURCES ${MPTV_HEADERS} ${TSREADER_SOURCES} ${TSREADER_HEADERS} ${LIVE555_SOURCES} ${LIVE555_HEADERS})
 
-set(DEPLIBS ${p8-platform_LIBRARIES}
-            ${TINYXML_LIBRARIES})
+set(DEPLIBS ${TINYXML_LIBRARIES})
 
 if(WIN32)
   list(APPEND DEPLIBS ws2_32)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-mediaportal-tvserver
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml-dev,
-               libp8-platform-dev, kodi-addon-dev
+               kodi-addon-dev
 Standards-Version: 4.1.2
 Section: libs
 Homepage: http://kodi.tv

--- a/depends/common/p8-platform/p8-platform.txt
+++ b/depends/common/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/xbmc/platform.git cee64e9dc0b69e8d286dc170a78effaabfa09c44

--- a/depends/windowsstore/p8-platform/p8-platform.txt
+++ b/depends/windowsstore/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/afedchin/platform.git win10

--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="8.1.0"
+  version="8.1.1"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,13 @@
+v8.1.1
+- Remove p8-platform dependency
+- Remove charset converter dependency
+- Use std::thread, std::mutex, condition_variable instead of event and bool defines
+- Use thread sleep_for instead of p8 time utils
+- Remove SAFE_DELETE
+- Use kodi StringUtils
+- Remove p8 os includes
+- Revert "Removed no more supported (C++17) declaration keyword (register)"
+
 v8.1.0
 - Update PVR API 7.1.0
 

--- a/src/GUIDialogRecordSettings.cpp
+++ b/src/GUIDialogRecordSettings.cpp
@@ -9,9 +9,9 @@
 #include "timers.h"
 #include "utils.h"
 #include "DateTime.h"
-#include "p8-platform/util/StringUtils.h"
 
 #include <kodi/General.h>
+#include <kodi/tools/StringUtils.h>
 
 /* Dialog item identifiers */
 #define BUTTON_OK                       1
@@ -106,7 +106,7 @@ bool CGUIDialogRecordSettings::OnInit()
 
   // Populate PreRecord spin control
   std::string marginStart;
-  marginStart = StringUtils::Format("%d (%s)", m_timerinfo.GetMarginStart(), kodi::GetLocalizedString(30136).c_str());
+  marginStart = kodi::tools::StringUtils::Format("%d (%s)", m_timerinfo.GetMarginStart(), kodi::GetLocalizedString(30136).c_str());
   m_spinPreRecord->SetType(kodi::gui::controls::ADDON_SPIN_CONTROL_TYPE_TEXT);
   m_spinPreRecord->AddLabel(kodi::GetLocalizedString(30135), -1);
   m_spinPreRecord->AddLabel(marginStart, m_timerinfo.GetMarginStart()); //value from XBMC
@@ -120,7 +120,7 @@ bool CGUIDialogRecordSettings::OnInit()
 
   // Populate PostRecord spin control
   std::string marginEnd;
-  marginEnd = StringUtils::Format("%d (%s)", m_timerinfo.GetMarginEnd(), kodi::GetLocalizedString(30136).c_str());
+  marginEnd = kodi::tools::StringUtils::Format("%d (%s)", m_timerinfo.GetMarginEnd(), kodi::GetLocalizedString(30136).c_str());
   m_spinPostRecord->SetType(kodi::gui::controls::ADDON_SPIN_CONTROL_TYPE_TEXT);
   m_spinPostRecord->AddLabel(kodi::GetLocalizedString(30135), -1);
   m_spinPostRecord->AddLabel(marginEnd, m_timerinfo.GetMarginEnd()); //value from XBMC

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -7,7 +7,6 @@
 
 #include "utils.h"
 #include <string>
-#include "p8-platform/os.h"
 #include "Socket.h"
 
 #include <kodi/General.h>

--- a/src/lib/tsreader/DeMultiplexer.cpp
+++ b/src/lib/tsreader/DeMultiplexer.cpp
@@ -104,7 +104,7 @@ namespace MPTV
         if (m_filter.IsSeeking())
             return 0;       // Ambass : to check
 
-        P8PLATFORM::CLockObject lock(m_sectionRead);
+        std::lock_guard<std::mutex> lock(m_sectionRead);
         if (NULL == m_reader)
             return 0;
 

--- a/src/lib/tsreader/DeMultiplexer.cpp
+++ b/src/lib/tsreader/DeMultiplexer.cpp
@@ -37,6 +37,8 @@
 #include <kodi/General.h>  //for kodi::Log
 #include "TSReader.h"
 
+#include <thread>
+
 #define MAX_BUF_SIZE 8000
 #define BUFFER_LENGTH 0x1000
 #define READ_SIZE (1316*30)
@@ -83,7 +85,7 @@ namespace MPTV
         {
             size_t BytesRead = ReadFromFile();
             if (0 == BytesRead)
-                usleep(10000);
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
         m_bStarting = false;
     }
@@ -248,7 +250,7 @@ namespace MPTV
         {
             size_t BytesRead = ReadFromFile();
             if (0 == BytesRead)
-                usleep(10000);
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
             dwBytesProcessed += BytesRead;
         }
 

--- a/src/lib/tsreader/DeMultiplexer.h
+++ b/src/lib/tsreader/DeMultiplexer.h
@@ -37,7 +37,7 @@
 #include "PacketSync.h"
 #include "TSHeader.h"
 #include "PatParser.h"
-#include "p8-platform/threads/mutex.h"
+#include <mutex>
 
 namespace MPTV
 {
@@ -60,7 +60,7 @@ namespace MPTV
     private:
         unsigned long long m_LastDataFromRtsp;
         bool m_bEndOfFile;
-        P8PLATFORM::CMutex m_sectionRead;
+        std::mutex m_sectionRead;
         FileReader* m_reader;
         CPatParser m_patParser;
         CTsReader& m_filter;

--- a/src/lib/tsreader/DvbUtil.cpp
+++ b/src/lib/tsreader/DvbUtil.cpp
@@ -77,7 +77,7 @@ namespace MPTV
     //*******************************************************************
     uint32_t crc32(char *data, int len)
     {
-        register int i;
+        int i;
         uint32_t crc = 0xffffffff;
 
         for (i = 0; i < len; i++)

--- a/src/lib/tsreader/DvbUtil.cpp
+++ b/src/lib/tsreader/DvbUtil.cpp
@@ -77,7 +77,7 @@ namespace MPTV
     //*******************************************************************
     uint32_t crc32(char *data, int len)
     {
-        int i;
+        register int i;
         uint32_t crc = 0xffffffff;
 
         for (i = 0; i < len; i++)

--- a/src/lib/tsreader/FileReader.cpp
+++ b/src/lib/tsreader/FileReader.cpp
@@ -37,10 +37,10 @@
 #include "TSDebug.h"
 #include "p8-platform/threads/threads.h"
 #include <algorithm> //std::min, std::max
-#include "p8-platform/util/timeutils.h" // for usleep
 #include "utils.h"
 #include <errno.h>
 
+#include <thread>
 
 /* indicate that caller can handle truncated reads, where function returns before entire buffer has been filled */
 #define READ_TRUNCATED 0x01
@@ -145,7 +145,8 @@ namespace MPTV
                     }
                 }
             }
-            usleep(20000);
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
         } while (--Tmo);
 
         if (Tmo)

--- a/src/lib/tsreader/FileReader.cpp
+++ b/src/lib/tsreader/FileReader.cpp
@@ -35,7 +35,7 @@
 #include "FileReader.h"
 #include <kodi/General.h> //for kodi::Log
 #include "TSDebug.h"
-#include "p8-platform/threads/threads.h"
+#include "os-dependent.h"
 #include <algorithm> //std::min, std::max
 #include "utils.h"
 #include <errno.h>

--- a/src/lib/tsreader/FileReader.cpp
+++ b/src/lib/tsreader/FileReader.cpp
@@ -38,7 +38,6 @@
 #include "p8-platform/threads/threads.h"
 #include <algorithm> //std::min, std::max
 #include "p8-platform/util/timeutils.h" // for usleep
-#include "p8-platform/util/util.h"
 #include "utils.h"
 #include <errno.h>
 
@@ -58,6 +57,14 @@
 /* calcuate bitrate for file while reading */
 #define READ_BITRATE   0x10
 
+template<typename T> void SafeDelete(T*& p)
+{
+  if (p)
+  {
+    delete p;
+    p = nullptr;
+  }
+}
 namespace MPTV
 {
     FileReader::FileReader() :

--- a/src/lib/tsreader/FileReader.h
+++ b/src/lib/tsreader/FileReader.h
@@ -33,7 +33,6 @@
  *  http://forums.dvbowners.com/
  */
 
-#include "p8-platform/os.h" // for __stat
 #include <string>
 #include <kodi/Filesystem.h>
 

--- a/src/lib/tsreader/MemoryBuffer.cpp
+++ b/src/lib/tsreader/MemoryBuffer.cpp
@@ -31,7 +31,6 @@
 
 #include "p8-platform/util/timeutils.h"
 #include "p8-platform/threads/mutex.h"
-#include "p8-platform/util/util.h"
 #include "MemoryBuffer.h"
 #include <kodi/General.h> //for kodi::Log
 #include "TSDebug.h"
@@ -57,13 +56,15 @@ bool CMemoryBuffer::IsRunning()
 void CMemoryBuffer::Clear()
 {
   P8PLATFORM::CLockObject BufferLock(m_BufferLock);
-  std::vector<BufferItem *>::iterator it = m_Array.begin();
 
-  for ( ; it != m_Array.end(); ++it )
+  for (auto& item : m_Array)
   {
-    BufferItem *item = *it;
-    SAFE_DELETE_ARRAY(item->data);
-    SAFE_DELETE(item);
+    if (item)
+    {
+      if (item->data)
+        delete[] item->data;
+      delete item;
+    }
   }
 
   m_Array.clear();
@@ -150,8 +151,9 @@ size_t CMemoryBuffer::ReadFromBuffer(unsigned char *pbData, size_t lDataLength)
     if (item->nOffset >= item->nDataLength)
     {
       m_Array.erase(m_Array.begin());
-      SAFE_DELETE_ARRAY(item->data);
-      SAFE_DELETE(item);
+      if (item->data)
+        delete[] item->data;
+      delete item;
     }
   }
   return bytesWritten;
@@ -182,8 +184,9 @@ long CMemoryBuffer::PutBuffer(unsigned char *pbData, size_t lDataLength)
 
       m_BytesInBuffer -= copyLength;
       m_Array.erase(m_Array.begin());
-      SAFE_DELETE_ARRAY(item2->data);
-      SAFE_DELETE(item2);
+      if (item2->data)
+        delete[] item2->data;
+      delete item2;
     }
     if (m_BytesInBuffer > 0)
     {

--- a/src/lib/tsreader/MemoryBuffer.cpp
+++ b/src/lib/tsreader/MemoryBuffer.cpp
@@ -29,11 +29,12 @@
 
 #ifdef LIVE555
 
-#include "p8-platform/util/timeutils.h"
 #include "p8-platform/threads/mutex.h"
 #include "MemoryBuffer.h"
 #include <kodi/General.h> //for kodi::Log
 #include "TSDebug.h"
+
+#include <thread>
 
 #define MAX_MEMORY_BUFFER_SIZE (1024L*1024L*12L)
 
@@ -196,7 +197,7 @@ long CMemoryBuffer::PutBuffer(unsigned char *pbData, size_t lDataLength)
 
   if (sleep)
   {
-    usleep(10000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   return S_OK;
 }

--- a/src/lib/tsreader/MemoryBuffer.h
+++ b/src/lib/tsreader/MemoryBuffer.h
@@ -30,7 +30,8 @@
 
 #ifdef LIVE555
 
-#include "p8-platform/threads/mutex.h"
+#include <condition_variable>
+#include <mutex>
 #include <vector>
 
 class CMemoryBuffer
@@ -55,9 +56,9 @@ class CMemoryBuffer
 
   protected:
     std::vector<BufferItem *> m_Array;
-    P8PLATFORM::CMutex m_BufferLock;
+    std::mutex m_BufferLock;
     size_t    m_BytesInBuffer;
-		P8PLATFORM::CEvent m_event;
+    std::condition_variable m_condition;
     bool m_bRunning;
 };
 #endif //LIVE555

--- a/src/lib/tsreader/MemoryReader.h
+++ b/src/lib/tsreader/MemoryReader.h
@@ -32,6 +32,7 @@
 
 #include "FileReader.h"
 #include "MemoryBuffer.h"
+#include "os-dependent.h"
 
 namespace MPTV
 {

--- a/src/lib/tsreader/MemorySink.cpp
+++ b/src/lib/tsreader/MemorySink.cpp
@@ -29,7 +29,6 @@
 
 #if defined LIVE555
 
-#include "p8-platform/os.h"
 #include "MemorySink.h"
 #include "GroupsockHelper.hh"
 #include <kodi/General.h> //for kodi::Log

--- a/src/lib/tsreader/MemorySink.cpp
+++ b/src/lib/tsreader/MemorySink.cpp
@@ -84,7 +84,7 @@ void CMemorySink::addData(unsigned char* data, size_t dataSize, struct timeval U
     return;
   }
 
-  P8PLATFORM::CLockObject BufferLock(m_BufferLock);
+  std::lock_guard<std::mutex> BufferLock(m_BufferLock);
 
   m_bReEntrant = true;
   m_buffer.PutBuffer(data, dataSize);

--- a/src/lib/tsreader/MemorySink.h
+++ b/src/lib/tsreader/MemorySink.h
@@ -35,7 +35,7 @@
 #endif
 
 #include "MemoryBuffer.h"
-#include "p8-platform/threads/mutex.h"
+#include <mutex>
 
 class CMemorySink: public MediaSink
 {
@@ -57,7 +57,7 @@ class CMemorySink: public MediaSink
   private: // redefined virtual functions:
     virtual Boolean continuePlaying();
 
-		P8PLATFORM::CMutex m_BufferLock;
+		std::mutex m_BufferLock;
     unsigned char* m_pSubmitBuffer;
     int   m_iSubmitBufferPos;
     bool  m_bReEntrant;

--- a/src/lib/tsreader/MepoRTSPClient.cpp
+++ b/src/lib/tsreader/MepoRTSPClient.cpp
@@ -18,12 +18,13 @@
 
 #if defined LIVE555
 
-#include "p8-platform/util/timeutils.h"
 #include "MepoRTSPClient.h"
 #include "MemorySink.h"
 #include <kodi/General.h> //for kodi::Log
 #include "utils.h"
 #include "os-dependent.h"
+
+#include <thread>
 
 CRTSPClient::CRTSPClient()
 {
@@ -531,7 +532,7 @@ void CRTSPClient::FillBuffer(unsigned long byteCount)
 
   while ( IsRunning() && m_buffer->Size() < byteCount)
   {
-    usleep(5000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
     if (GetTickCount64() - tickCount > 3000)
       break;
   }

--- a/src/lib/tsreader/MepoRTSPClient.h
+++ b/src/lib/tsreader/MepoRTSPClient.h
@@ -31,7 +31,8 @@
 
 #ifdef LIVE555
 
-#include "p8-platform/threads/threads.h"
+#include <atomic>
+#include <thread>
 #include "lib/tsreader/MemoryBuffer.h"
 
 #include "liveMedia.hh"
@@ -41,7 +42,7 @@
 
 #define RTSP_URL_BUFFERSIZE 2048
 
-class CRTSPClient: public P8PLATFORM::CThread
+class CRTSPClient
 {
 public:
   CRTSPClient();
@@ -101,7 +102,7 @@ public:
 
   // Thread
 private:
-  virtual void *Process(void);
+  void Process();
   void StartBufferThread();
   void StopBufferThread();
   bool m_BufferThreadActive;
@@ -113,5 +114,8 @@ private:
   bool m_bRunning;
   bool m_bPaused;
   char m_outFileName[1000];
+
+  std::atomic<bool> m_running = {false};
+  std::thread m_thread;
 };
 #endif //LIVE555

--- a/src/lib/tsreader/MultiFileReader.cpp
+++ b/src/lib/tsreader/MultiFileReader.cpp
@@ -48,6 +48,15 @@ using namespace P8PLATFORM;
 //Maximum time in msec to wait for the buffer file to become available - Needed for DVB radio (this sometimes takes some time)
 #define MAX_BUFFER_TIMEOUT 1500
 
+template<typename T> void SafeDelete(T*& p)
+{
+  if (p)
+  {
+    delete p;
+    p = nullptr;
+  }
+}
+
 namespace MPTV
 {
     MultiFileReader::MultiFileReader() :
@@ -484,7 +493,7 @@ namespace MPTV
 
                 TSDEBUG(ADDON_LOG_DEBUG, "MultiFileReader: Removing file %s\n", file->filename.c_str());
 
-                SAFE_DELETE(file);
+                SafeDelete(file);
                 m_tsFiles.erase(m_tsFiles.begin());
 
                 filesToRemove--;

--- a/src/lib/tsreader/MultiFileReader.cpp
+++ b/src/lib/tsreader/MultiFileReader.cpp
@@ -35,16 +35,15 @@
 #include "MultiFileReader.h"
 #include <kodi/General.h> //for kodi::Log
 #include <kodi/Filesystem.h>
+#include <kodi/tools/EndTime.h>
 #include "TSDebug.h"
 #include <string>
 #include "utils.h"
 #include <algorithm>
-#include "p8-platform/threads/threads.h"
 #include <inttypes.h>
+#include "os-dependent.h"
 
 #include <thread>
-
-using namespace P8PLATFORM;
 
 //Maximum time in msec to wait for the buffer file to become available - Needed for DVB radio (this sometimes takes some time)
 #define MAX_BUFFER_TIMEOUT 1500
@@ -121,12 +120,12 @@ namespace MPTV
         if (RefreshTSBufferFile() == S_FALSE)
         {
             // For radio the buffer sometimes needs some time to become available, so wait and try it more than once
-            P8PLATFORM::CTimeout timeout(MAX_BUFFER_TIMEOUT);
+            kodi::tools::CEndTime timeout(MAX_BUFFER_TIMEOUT);
 
             do
             {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                if (timeout.TimeLeft() == 0)
+                if (timeout.MillisLeft() == 0)
                 {
                     kodi::Log(ADDON_LOG_ERROR, "MultiFileReader: timed out while waiting for buffer file to become available");
                     kodi::QueueNotification(QUEUE_ERROR, "", "Time out while waiting for buffer file");

--- a/src/lib/tsreader/MultiFileReader.cpp
+++ b/src/lib/tsreader/MultiFileReader.cpp
@@ -39,9 +39,10 @@
 #include <string>
 #include "utils.h"
 #include <algorithm>
-#include "p8-platform/util/timeutils.h"
 #include "p8-platform/threads/threads.h"
 #include <inttypes.h>
+
+#include <thread>
 
 using namespace P8PLATFORM;
 
@@ -112,7 +113,7 @@ namespace MPTV
             retryCount++;
             kodi::Log(ADDON_LOG_DEBUG, "MultiFileReader: buffer file has zero length, closing, waiting 100 ms and re-opening. Attempt: %d.", retryCount);
             m_TSBufferFile.CloseFile();
-            usleep(100000);
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
             hResult = m_TSBufferFile.OpenFile();
             kodi::Log(ADDON_LOG_DEBUG, "MultiFileReader: buffer file opened return code %d.", hResult);
         }
@@ -124,7 +125,7 @@ namespace MPTV
 
             do
             {
-                usleep(100000);
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
                 if (timeout.TimeLeft() == 0)
                 {
                     kodi::Log(ADDON_LOG_ERROR, "MultiFileReader: timed out while waiting for buffer file to become available");
@@ -457,7 +458,7 @@ namespace MPTV
                 // try to clear local / remote SMB file cache. This should happen when we close the filehandle
                 m_TSBufferFile.CloseFile();
                 m_TSBufferFile.OpenFile();
-                usleep(5000);
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
             }
 
             if (Error)

--- a/src/lib/tsreader/Section.cpp
+++ b/src/lib/tsreader/Section.cpp
@@ -22,6 +22,8 @@
 #include "os-dependent.h"
 #include "Section.h"
 
+#include <cstring>
+
 namespace MPTV
 {
     CSection::CSection(void)

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -33,7 +33,6 @@
 #include "MultiFileReader.h"
 #include "utils.h"
 #include "TSDebug.h"
-#include "p8-platform/util/timeutils.h"
 #include <kodi/tools/StringUtils.h>
 #ifdef LIVE555
 #include "MemoryReader.h"
@@ -41,6 +40,8 @@
 #include "MemoryBuffer.h"
 #endif
 #include "FileUtils.h"
+
+#include <thread>
 
 using namespace std;
 
@@ -396,7 +397,7 @@ namespace MPTV
                 fileReader->OnChannelChange();
 
                 kodi::Log(ADDON_LOG_DEBUG, "%s:: move from %I64d to %I64d tsbufpos  %I64d", __FUNCTION__, pos_before, pos_after, timeShiftBufferPos);
-                usleep(100000);
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
                 // Set the stream start times to this new channel
                 time(&m_startTime);

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -44,6 +44,15 @@
 
 using namespace std;
 
+template<typename T> void SafeDelete(T*& p)
+{
+  if (p)
+  {
+    delete p;
+    p = nullptr;
+  }
+}
+
 namespace MPTV
 {
     CTsReader::CTsReader() : m_demultiplexer(*this),
@@ -69,10 +78,10 @@ namespace MPTV
 
     CTsReader::~CTsReader(void)
     {
-        SAFE_DELETE(m_fileReader);
+        SafeDelete(m_fileReader);
 #ifdef LIVE555
-        SAFE_DELETE(m_buffer);
-        SAFE_DELETE(m_rtspClient);
+        SafeDelete(m_buffer);
+        SafeDelete(m_rtspClient);
 #endif
     }
 
@@ -225,8 +234,8 @@ namespace MPTV
 
             if ( !m_rtspClient->OpenStream(m_fileName.c_str()) )
             {
-                SAFE_DELETE(m_rtspClient);
-                SAFE_DELETE(m_buffer);
+                SafeDelete(m_rtspClient);
+                SafeDelete(m_buffer);
                 return E_FAIL;
             }
 
@@ -318,8 +327,8 @@ namespace MPTV
 #ifdef LIVE555
                 kodi::Log(ADDON_LOG_INFO, "TsReader: closing RTSP client");
                 m_rtspClient->Stop();
-                SAFE_DELETE(m_rtspClient);
-                SAFE_DELETE(m_buffer);
+                SafeDelete(m_rtspClient);
+                SafeDelete(m_buffer);
 #endif
             }
             else
@@ -327,7 +336,7 @@ namespace MPTV
                 kodi::Log(ADDON_LOG_INFO, "TsReader: closing file");
                 m_fileReader->CloseFile();
             }
-            SAFE_DELETE(m_fileReader);
+            SafeDelete(m_fileReader);
             m_State = State_Stopped;
         }
     }

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -34,7 +34,7 @@
 #include "utils.h"
 #include "TSDebug.h"
 #include "p8-platform/util/timeutils.h"
-#include "p8-platform/util/StringUtils.h"
+#include <kodi/tools/StringUtils.h>
 #ifdef LIVE555
 #include "MemoryReader.h"
 #include "MepoRTSPClient.h"
@@ -104,7 +104,7 @@ namespace MPTV
             {
                 if (!tscard.TimeshiftFolderUNC.empty())
                 {
-                    StringUtils::Replace(sFileName, tscard.TimeshiftFolder.c_str(), tscard.TimeshiftFolderUNC.c_str());
+                    kodi::tools::StringUtils::Replace(sFileName, tscard.TimeshiftFolder.c_str(), tscard.TimeshiftFolderUNC.c_str());
                     bFound = true;
                 }
                 else
@@ -129,7 +129,7 @@ namespace MPTV
                         if (!it->RecordingFolderUNC.empty())
                         {
                             // Remove the original base path and replace it with the given path
-                            StringUtils::Replace(sFileName, it->RecordingFolder.c_str(), it->RecordingFolderUNC.c_str());
+                            kodi::tools::StringUtils::Replace(sFileName, it->RecordingFolder.c_str(), it->RecordingFolderUNC.c_str());
                             bFound = true;
                             break;
                         }
@@ -412,8 +412,8 @@ namespace MPTV
         if (tmp.find("smb://") != string::npos)
         {
           // Convert XBMC smb share name back to a real windows network share...
-          StringUtils::Replace(tmp, "smb://", "\\\\");
-          StringUtils::Replace(tmp, "/", "\\");
+          kodi::tools::StringUtils::Replace(tmp, "smb://", "\\\\");
+          kodi::tools::StringUtils::Replace(tmp, "/", "\\");
         }
 #else
         //TODO: do something useful...

--- a/src/os-dependent.h
+++ b/src/os-dependent.h
@@ -7,29 +7,33 @@
 
 #pragma once
 
-#include "p8-platform/os.h"
+#include <cstdint>
 
-#ifdef TARGET_LINUX
-// Retrieve the number of milliseconds that have elapsed since the system was started
-#include <time.h>
+#if (defined(_WIN32) || defined(_WIN64))
+
+#ifndef _SSIZE_T_DEFINED
+#ifdef  _WIN64
+typedef __int64    ssize_t;
+#else
+typedef _W64 int   ssize_t;
+#endif
+#define _SSIZE_T_DEFINED
+#endif
+
+#else
+
+#if (defined(TARGET_LINUX) || defined(TARGET_DARWIN))
+#include <sys/types.h>
+#include <chrono>
+#include <cstring>
 inline unsigned long long GetTickCount64(void)
 {
-  struct timespec ts;
-  if(clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
-  {
-    return 0;
-  }
-  return (unsigned long long)( (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000) );
-};
-#elif defined(TARGET_DARWIN)
-#include <time.h>
-inline unsigned long long GetTickCount64(void)
-{
-  struct timeval tv;
-  gettimeofday(&tv, NULL);
-  return (unsigned long long)( (tv.tv_sec * 1000) + (tv.tv_usec / 1000) );
+  auto now = std::chrono::steady_clock::now();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
 };
 #endif /* TARGET_LINUX || TARGET_DARWIN */
+
+#endif
 
 // Additional typedefs
 typedef uint8_t byte;

--- a/src/os-dependent.h
+++ b/src/os-dependent.h
@@ -11,6 +11,13 @@
 
 #if (defined(_WIN32) || defined(_WIN64))
 
+#include <wchar.h>
+
+/* Handling of 2-byte Windows wchar strings */
+#define WcsLen wcslen
+#define WcsToMbs wcstombs
+typedef wchar_t Wchar_t; /* sizeof(wchar_t) = 2 bytes on Windows */
+
 #ifndef _SSIZE_T_DEFINED
 #ifdef  _WIN64
 typedef __int64    ssize_t;
@@ -20,19 +27,107 @@ typedef _W64 int   ssize_t;
 #define _SSIZE_T_DEFINED
 #endif
 
+/* Prevent deprecation warnings */
+#define strnicmp _strnicmp
+
+#define PATH_SEPARATOR_CHAR '\\'
+
 #else
 
 #if (defined(TARGET_LINUX) || defined(TARGET_DARWIN))
 #include <sys/types.h>
 #include <chrono>
 #include <cstring>
+
+#define strnicmp(X,Y,N) strncasecmp(X,Y,N)
+
 inline unsigned long long GetTickCount64(void)
 {
   auto now = std::chrono::steady_clock::now();
   return std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
 };
+
+#define PATH_SEPARATOR_CHAR '/'
+
+#if defined(__APPLE__)
+// for HRESULT
+#include <CoreFoundation/CFPlugInCOM.h>
+#endif
+
+/* Handling of 2-byte Windows wchar strings on non-Windows targets
+ * Used by The MediaPortal and ForTheRecord pvr addons
+ */
+typedef uint16_t Wchar_t; /* sizeof(wchar_t) = 4 bytes on Linux, but the MediaPortal buffer files have 2-byte wchars */
+
+/* This is a replacement of the Windows wcslen() function which assumes that
+ * wchar_t is a 2-byte character.
+ * It is used for processing Windows wchar strings
+ */
+inline size_t WcsLen(const Wchar_t *str)
+{
+  const unsigned short *eos = (const unsigned short*)str;
+  while( *eos++ ) ;
+  return( (size_t)(eos - (const unsigned short*)str) -1);
+};
+
+/* This is a replacement of the Windows wcstombs() function which assumes that
+ * wchar_t is a 2-byte character.
+ * It is used for processing Windows wchar strings
+ */
+inline size_t WcsToMbs(char *s, const Wchar_t *w, size_t n)
+{
+  size_t i = 0;
+  const unsigned short *wc = (const unsigned short*) w;
+  while(wc[i] && (i < n))
+  {
+    s[i] = wc[i];
+    ++i;
+  }
+  if (i < n) s[i] = '\0';
+
+  return (i);
+};
+
 #endif /* TARGET_LINUX || TARGET_DARWIN */
 
+#endif
+
+typedef long LONG;
+#if !defined(__APPLE__)
+typedef LONG HRESULT;
+#endif
+
+#ifndef FAILED
+#define FAILED(Status) ((HRESULT)(Status)<0)
+#endif
+
+#ifndef SUCCEEDED
+#define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
+#endif
+
+#define _FILE_OFFSET_BITS 64
+#define FILE_BEGIN              0
+#define FILE_CURRENT            1
+#define FILE_END                2
+
+#ifndef S_OK
+#define S_OK           0L
+#endif
+
+#ifndef S_FALSE
+#define S_FALSE        1L
+#endif
+
+// Error codes
+#define ERROR_FILENAME_EXCED_RANGE 206L
+#define ERROR_INVALID_NAME         123L
+
+#ifndef E_OUTOFMEMORY
+#define E_OUTOFMEMORY              0x8007000EL
+#endif
+
+#ifndef E_FAIL
+#define E_FAIL                     0x8004005EL
 #endif
 
 // Additional typedefs

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <clocale>
 
-#include "p8-platform/util/timeutils.h"
 #include <kodi/tools/StringUtils.h>
 
 #include "timers.h"
@@ -28,6 +27,8 @@
 
 #include <kodi/General.h>
 #include <kodi/Filesystem.h>
+
+#include <thread>
 
 using namespace kodi::tools;
 using namespace std;
@@ -389,7 +390,7 @@ void* cPVRClientMediaPortal::Process(void)
     if (keepWaiting)
     {
       // Wait for 1 minute before re-trying
-      usleep(60000000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(60000));
     }
   }
   SetConnectionState(state);
@@ -1571,7 +1572,8 @@ PVR_ERROR cPVRClientMediaPortal::AddTimer(const kodi::addon::PVRTimer& timerinfo
   if (timerinfo.GetStartTime() <= 0)
   {
     // Refresh the recordings list to see the newly created recording
-    usleep(100000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
     kodi::addon::CInstancePVRClient::TriggerRecordingUpdate();
   }
 
@@ -1785,7 +1787,8 @@ bool cPVRClientMediaPortal::OpenLiveStream(const kodi::addon::PVRChannel& channe
       kodi::Log(ADDON_LOG_INFO, "Channel timeshift buffer: %s", timeshiftfields[2].c_str());
       if (channelinfo.GetIsRadio())
       {
-        usleep(100000); // 100 ms sleep to allow the buffer to fill
+        // 100 ms sleep to allow the buffer to fill
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
     }
     else
@@ -1796,7 +1799,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const kodi::addon::PVRChannel& channe
     if (CSettings::Get().GetSleepOnRTSPurl() > 0)
     {
       kodi::Log(ADDON_LOG_INFO, "Sleeping %i ms before opening stream: %s", CSettings::Get().GetSleepOnRTSPurl(), timeshiftfields[0].c_str());
-      usleep(CSettings::Get().GetSleepOnRTSPurl() * 1000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(CSettings::Get().GetSleepOnRTSPurl()));
     }
 
     // Check the returned stream URL. When the URL is an rtsp stream, we need
@@ -1878,7 +1881,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const kodi::addon::PVRChannel& channe
           CloseLiveStream();
           return false;
         }
-        usleep(400000);
+        std::this_thread::sleep_for(std::chrono::milliseconds(400));
       }
     }
 
@@ -1924,7 +1927,7 @@ int cPVRClientMediaPortal::ReadLiveStream(unsigned char *pBuffer, unsigned int i
 
     if (m_tsreader->Read(bufptr, read_wanted, &read_wanted) > 0)
     {
-      usleep(20000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
       read_timeouts++;
       return static_cast<int>(read_wanted);
     }
@@ -1948,7 +1951,7 @@ int cPVRClientMediaPortal::ReadLiveStream(unsigned char *pBuffer, unsigned int i
       }
       bufptr += read_wanted;
       read_timeouts++;
-      usleep(10000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
   read_timeouts = 0;
@@ -2175,7 +2178,7 @@ int cPVRClientMediaPortal::ReadRecordedStream(unsigned char *pBuffer, unsigned i
 
     if (m_tsreader->Read(bufptr, read_wanted, &read_wanted) > 0)
     {
-      usleep(20000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
       return static_cast<int>(read_wanted);
     }
     read_done += read_wanted;
@@ -2183,7 +2186,7 @@ int cPVRClientMediaPortal::ReadRecordedStream(unsigned char *pBuffer, unsigned i
     if ( read_done < static_cast<size_t>(iBufferSize) )
     {
       bufptr += read_wanted;
-      usleep(20000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
     }
   }
 

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -11,7 +11,7 @@
 #include <clocale>
 
 #include "p8-platform/util/timeutils.h"
-#include "p8-platform/util/StringUtils.h"
+#include <kodi/tools/StringUtils.h>
 
 #include "timers.h"
 #include "channels.h"
@@ -29,6 +29,7 @@
 #include <kodi/General.h>
 #include <kodi/Filesystem.h>
 
+using namespace kodi::tools;
 using namespace std;
 using namespace MPTV;
 

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -42,6 +42,15 @@ int g_iTVServerKodiBuild = 0;
 #define TVSERVERKODI_RECOMMENDED_VERSION_STRING "1.2.3.122 till 1.20.0.140"
 #define TVSERVERKODI_RECOMMENDED_VERSION_BUILD  140
 
+template<typename T> void SafeDelete(T*& p)
+{
+  if (p)
+  {
+    delete p;
+    p = nullptr;
+  }
+}
+
 /************************************************************/
 /** Class interface */
 
@@ -75,10 +84,10 @@ cPVRClientMediaPortal::~cPVRClientMediaPortal()
   kodi::Log(ADDON_LOG_DEBUG, "->~cPVRClientMediaPortal()");
   Disconnect();
 
-  SAFE_DELETE(Timer::lifetimeValues);
-  SAFE_DELETE(m_tcpclient);
-  SAFE_DELETE(m_genretable);
-  SAFE_DELETE(m_lastSelectedRecording);
+  SafeDelete(Timer::lifetimeValues);
+  SafeDelete(m_tcpclient);
+  SafeDelete(m_genretable);
+  SafeDelete(m_lastSelectedRecording);
 }
 
 string cPVRClientMediaPortal::SendCommand(const char* command)
@@ -321,7 +330,7 @@ void cPVRClientMediaPortal::Disconnect()
       if ((CSettings::Get().GetStreamingMethod()==TSReader) && (m_tsreader != NULL))
       {
         m_tsreader->Close();
-        SAFE_DELETE(m_tsreader);
+        SafeDelete(m_tsreader);
       }
       SendCommand("StopTimeshift:\n");
     }
@@ -1748,7 +1757,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const kodi::addon::PVRChannel& channe
     m_iCurrentChannel = -1;
     if (m_tsreader != nullptr)
     {
-      SAFE_DELETE(m_tsreader);
+      SafeDelete(m_tsreader);
     }
     return false;
   }
@@ -1959,7 +1968,7 @@ void cPVRClientMediaPortal::CloseLiveStream(void)
     if (CSettings::Get().GetStreamingMethod() == TSReader && m_tsreader)
     {
       m_tsreader->Close();
-      SAFE_DELETE(m_tsreader);
+      SafeDelete(m_tsreader);
     }
     result = SendCommand("StopTimeshift:\n");
     kodi::Log(ADDON_LOG_INFO, "CloseLiveStream: %s", result.c_str());
@@ -2141,7 +2150,7 @@ void cPVRClientMediaPortal::CloseRecordedStream(void)
   {
     kodi::Log(ADDON_LOG_INFO, "CloseRecordedStream: Stop TSReader...");
     m_tsreader->Close();
-    SAFE_DELETE(m_tsreader);
+    SafeDelete(m_tsreader);
   }
   else
   {
@@ -2409,7 +2418,7 @@ cRecording* cPVRClientMediaPortal::GetRecordingInfo(const kodi::addon::PVRRecord
     {
       return m_lastSelectedRecording;
     }
-    SAFE_DELETE(m_lastSelectedRecording);
+    SafeDelete(m_lastSelectedRecording);
   }
 
   if (!IsUp())

--- a/src/timers.cpp
+++ b/src/timers.cpp
@@ -11,7 +11,6 @@
 
 using namespace std;
 
-#include "p8-platform/os.h" //needed for snprintf
 #include "timers.h"
 #include "settings.h"
 #include "utils.h"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,8 +13,9 @@
 #include "settings.h"
 #include <string>
 #include <stdio.h>
-#include "p8-platform/util/StringUtils.h"
+#include <kodi/tools/StringUtils.h>
 
+using namespace kodi::tools;
 using namespace std;
 
 void Tokenize(const string& str, vector<string>& tokens, const string& delimiters = " ")

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,12 +11,10 @@
 #include <vector>
 #include <ctime>
 #include "uri.h"
-#include "p8-platform/util/util.h"
 
 #ifdef TARGET_WINDOWS
 #include "windows/WindowsUtils.h"
 #endif
-
 
 /**
  * String tokenize

--- a/src/windows/FileUtils.cpp
+++ b/src/windows/FileUtils.cpp
@@ -6,12 +6,16 @@
  */
 
 #include "../FileUtils.h"
-#include "p8-platform/os.h"
 #include "p8-platform/windows/CharsetConverter.h"
 #include <string>
 #include "../utils.h"
 #ifdef TARGET_WINDOWS_DESKTOP
 #include <Shlobj.h>
+#endif
+
+#ifdef TARGET_WINDOWS
+#include <windows.h>
+#include <fileapi.h>
 #endif
 
 namespace OS

--- a/src/windows/FileUtils.cpp
+++ b/src/windows/FileUtils.cpp
@@ -6,24 +6,36 @@
  */
 
 #include "../FileUtils.h"
-#include "p8-platform/windows/CharsetConverter.h"
 #include <string>
 #include "../utils.h"
 #ifdef TARGET_WINDOWS_DESKTOP
 #include <Shlobj.h>
 #endif
 
-#ifdef TARGET_WINDOWS
 #include <windows.h>
 #include <fileapi.h>
-#endif
+
+std::wstring ToW(const char* str, size_t length)
+{
+  int result = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, length, nullptr, 0);
+  if (result == 0)
+    return std::wstring();
+
+  auto newStr = std::make_unique<wchar_t[]>(result);
+  result = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, length, newStr.get(), result);
+
+  if (result == 0)
+    return std::wstring();
+
+  return std::wstring(newStr.get(), result);
+}
 
 namespace OS
 {
   bool CFile::Exists(const std::string& strFileName, long* errCode)
   {
     std::string strWinFile = ToWindowsPath(strFileName);
-    std::wstring strWFile = p8::windows::ToW(strWinFile.c_str());
+    std::wstring strWFile = ToW(strWinFile.c_str(), 0);
     DWORD dwAttr = GetFileAttributesW(strWFile.c_str());
 
     if(dwAttr != 0xffffffff)


### PR DESCRIPTION
v8.0.1
- Remove p8-platform dependency
- Remove charset converter dependency
- Use std::thread, std::mutex, condition_variable instead of event and bool defines
- Use thread sleep_for instead of p8 time utils
- Remove SAFE_DELETE
- Use kodi StringUtils
- Remove p8 os includes
- Revert "Removed no more supported (C++17) declaration keyword (register)"