### PR TITLE
Implement GetRecordingEdl where using remote smb share

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="8.1.2"
+  version="8.2.0"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v8.2.0
+- Support edl files over remote smb shares for commercial skipping 
+
 v8.1.2
 - Fix MultiByteToWideChar parameter
 

--- a/src/lib/tsreader/TSReader.h
+++ b/src/lib/tsreader/TSReader.h
@@ -80,14 +80,13 @@ namespace MPTV
         long Pause(bool bPaused);
 
         TsReaderState State() { return m_State; };
-
-    private:
-
         /**
          * \brief Translate the given path using the m_basePath setting
          * \param The original (local) timeshift buffer file path on the TV server side
          */
-        std::string TranslatePath(const char* pszFileName);
+        std::string TranslatePath(const char* pszFileName); 
+
+    private:
 
         bool            m_bTimeShifting;
         bool            m_bRecording;

--- a/src/pvrclient-mediaportal.h
+++ b/src/pvrclient-mediaportal.h
@@ -70,6 +70,7 @@ public:
   PVR_ERROR SetRecordingPlayCount(const kodi::addon::PVRRecording& recording, int count) override;
   PVR_ERROR SetRecordingLastPlayedPosition(const kodi::addon::PVRRecording& recording, int lastplayedposition) override;
   PVR_ERROR GetRecordingLastPlayedPosition(const kodi::addon::PVRRecording& recording, int& position) override;
+  PVR_ERROR GetRecordingEdl(const kodi::addon::PVRRecording& recording, std::vector<kodi::addon::PVREDLEntry>& edl) override;
 
   /* Timer handling */
   PVR_ERROR GetTimersAmount(int& amount) override;


### PR DESCRIPTION
Following the discussion under the issue #131, I have created the changes to allow mediaportal to access comskip edl files even if
kodi is on a system remote from the mediaportal server. I believe the change is fully backward compatible and I've tested it on windows, android and linux ( ubuntu 20.04 ). Hoping it meets the requirements for code changes, happy to modify further if not.