### PR TITLE
Revert std:stoi to std:atoi calls to avoid conversion errors

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="20.1.0"
+  version="20.1.1"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v20.1.1
+- Revert std:stoi to std:atoi calls to avoid conversion errors
+
 v20.1.0
 - Kodi API to 8.0.0
   - Add supports recordings delete capability

--- a/src/epg.cpp
+++ b/src/epg.cpp
@@ -94,12 +94,12 @@ bool cEpg::ParseLine(string& data)
       {
         // Since TVServerKodi v1.x.x.104
         m_uid = (unsigned int) cKodiEpgIndexOffset + atol(epgfields[5].c_str());
-        m_seriesNumber = !epgfields[7].empty() ? std::stoi(epgfields[7]) : EPG_TAG_INVALID_SERIES_EPISODE;
-        m_episodeNumber = !epgfields[8].empty() ? std::stoi(epgfields[8]) : EPG_TAG_INVALID_SERIES_EPISODE;
+        m_seriesNumber = !epgfields[7].empty() ? std::atoi(epgfields[7].c_str()) : EPG_TAG_INVALID_SERIES_EPISODE;
+        m_episodeNumber = !epgfields[8].empty() ? std::atoi(epgfields[8].c_str()) : EPG_TAG_INVALID_SERIES_EPISODE;
         m_episodeName = epgfields[9];
         m_episodePart = epgfields[10];
-        m_starRating = !epgfields[13].empty() ? std::stoi(epgfields[13]) : 0;
-        m_parentalRating = !epgfields[14].empty() ? std::stoi(epgfields[14]) : 0;
+        m_starRating = !epgfields[13].empty() ? std::atoi(epgfields[13].c_str()) : 0;
+        m_parentalRating = !epgfields[14].empty() ? std::atoi(epgfields[14].c_str()) : 0;
 
         //originalAirDate
         if( m_originalAirDate.SetFromDateTime(epgfields[11]) == false )

--- a/src/pvrclient-mediaportal.cpp
+++ b/src/pvrclient-mediaportal.cpp
@@ -525,7 +525,7 @@ PVR_ERROR cPVRClientMediaPortal::GetBackendTime(time_t *localTime, int *gmtOffse
     //[1] UTC offset hours
     //[2] UTC offset minutes
     //From CPVREpg::CPVREpg(): Expected PVREpg GMT offset is in seconds
-    m_BackendUTCoffset = ((std::stoi(fields[1]) * 60) + std::stoi(fields[2])) * 60;
+    m_BackendUTCoffset = ((atoi(fields[1].c_str()) * 60) + atoi(fields[2].c_str())) * 60;
 
     int count = sscanf(fields[0].c_str(), "%4d-%2d-%2d %2d:%2d:%2d", &year, &month, &day, &hour, &minute, &second);
 
@@ -1256,7 +1256,7 @@ PVR_ERROR cPVRClientMediaPortal::SetRecordingPlayCount(const kodi::addon::PVRRec
   char           command[512];
   string         result;
 
-  snprintf(command, 512, "SetRecordingTimesWatched:%i|%i\n", std::stoi(recording.GetRecordingId()), count);
+  snprintf(command, 512, "SetRecordingTimesWatched:%i|%i\n", std::atoi(recording.GetRecordingId().c_str()), count);
 
   result = SendCommand(command);
 
@@ -1288,7 +1288,7 @@ PVR_ERROR cPVRClientMediaPortal::SetRecordingLastPlayedPosition(const kodi::addo
     lastplayedposition = 0;
   }
 
-  snprintf(command, 512, "SetRecordingStopTime:%i|%i\n", std::stoi(recording.GetRecordingId()), lastplayedposition);
+  snprintf(command, 512, "SetRecordingStopTime:%i|%i\n", std::atoi(recording.GetRecordingId().c_str()), lastplayedposition);
 
   result = SendCommand(command);
 
@@ -1315,7 +1315,7 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordingLastPlayedPosition(const kodi::addo
   char           command[512];
   string         result;
 
-  snprintf(command, 512, "GetRecordingStopTime:%i\n", std::stoi(recording.GetRecordingId()));
+  snprintf(command, 512, "GetRecordingStopTime:%i\n", std::atoi(recording.GetRecordingId().c_str()));
 
   result = SendCommand(command);
 
@@ -1325,7 +1325,7 @@ PVR_ERROR cPVRClientMediaPortal::GetRecordingLastPlayedPosition(const kodi::addo
     return PVR_ERROR_UNKNOWN;
   }
 
-  position = std::stoi(result);
+  position = std::atoi(result.c_str());
 
   kodi::Log(ADDON_LOG_DEBUG, "%s: id=%s stoptime=%i {s} [successful]", __FUNCTION__, recording.GetRecordingId().c_str(), position);
 
@@ -1732,7 +1732,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const kodi::addon::PVRChannel& channe
         //  NoPmtFound = 16,
         //};
 
-        int tvresult = std::stoi(timeshiftfields[1]);
+        int tvresult = std::atoi(timeshiftfields[1].c_str());
         // Display one of the localized error messages 30060-30075
         kodi::QueueNotification(QUEUE_ERROR, "", kodi::GetLocalizedString(30059 + tvresult));
       }
@@ -1820,7 +1820,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const kodi::addon::PVRChannel& channe
         //if(g_bDirectTSFileRead)
         if(CSettings::Get().GetUseRTSP() == false)
         {
-          m_tsreader->SetCardId(std::stoi(timeshiftfields[3]));
+          m_tsreader->SetCardId(std::atoi(timeshiftfields[3].c_str()));
 
           if ((g_iTVServerKodiBuild >=110) && (timeshiftfields.size()>=6))
             bReturn = m_tsreader->OnZap(timeshiftfields[2].c_str(), atoll(timeshiftfields[4].c_str()), atol(timeshiftfields[5].c_str()));
@@ -1837,7 +1837,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const kodi::addon::PVRChannel& channe
         if (bReturn)
         {
           m_iCurrentChannel = (int) channelinfo.GetUniqueId();
-          m_iCurrentCard = std::stoi(timeshiftfields[3]);
+          m_iCurrentCard = std::atoi(timeshiftfields[3].c_str());
           m_bCurrentChannelIsRadio = channelinfo.GetIsRadio();
         }
         else
@@ -1858,7 +1858,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const kodi::addon::PVRChannel& channe
       {
         // Reading directly from the Timeshift buffer
         m_tsreader->SetCardSettings(&m_cCards);
-        m_tsreader->SetCardId(std::stoi(timeshiftfields[3]));
+        m_tsreader->SetCardId(std::atoi(timeshiftfields[3].c_str()));
 
         //if (g_szTimeshiftDir.length() > 0)
         //  m_tsreader->SetDirectory(g_szTimeshiftDir);
@@ -1885,7 +1885,7 @@ bool cPVRClientMediaPortal::OpenLiveStream(const kodi::addon::PVRChannel& channe
 
     // at this point everything is ready for playback
     m_iCurrentChannel = (int) channelinfo.GetUniqueId();
-    m_iCurrentCard = std::stoi(timeshiftfields[3]);
+    m_iCurrentCard = std::atoi(timeshiftfields[3].c_str());
     m_bCurrentChannelIsRadio = channelinfo.GetIsRadio();
   }
   kodi::Log(ADDON_LOG_INFO, "OpenLiveStream: success for channel id %i (%s) on card %i", m_iCurrentChannel, channelinfo.GetChannelName().c_str(), m_iCurrentCard);
@@ -2414,7 +2414,7 @@ cRecording* cPVRClientMediaPortal::GetRecordingInfo(const kodi::addon::PVRRecord
   // Is this the same recording as the previous one?
   if (m_lastSelectedRecording)
   {
-    int recId = std::stoi(recording.GetRecordingId());
+    int recId = std::atoi(recording.GetRecordingId().c_str());
     if (m_lastSelectedRecording->Index() == recId)
     {
       return m_lastSelectedRecording;


### PR DESCRIPTION
v20.1.1
- Revert std:stoi to std:atoi calls to avoid conversion errors