### PR TITLE
Use READ_NO_BUFFER for opening files with Kodi Omega 21.1

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="21.0.2"
+  version="21.0.3"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v21.0.3
+- Use READ_NO_BUFFER for opening files with Kodi Omega 21.1
+
 v21.0.2
 - Update FileReader open mode so it is compatible with Kodi Omega
 

--- a/src/lib/tsreader/FileReader.cpp
+++ b/src/lib/tsreader/FileReader.cpp
@@ -57,6 +57,9 @@
 /* calcuate bitrate for file while reading */
 #define READ_BITRATE   0x10
 
+/* cindicate that caller want open a file without intermediate buffer regardless to file type */
+#define READ_NO_BUFFER 0x200
+
 template<typename T> void SafeDelete(T*& p)
 {
   if (p)
@@ -125,7 +128,7 @@ namespace MPTV
         do
         {
             kodi::Log(ADDON_LOG_INFO, "FileReader::OpenFile() %s.", m_fileName.c_str());
-            if (m_hFile.OpenFile(m_fileName, READ_NO_CACHE | READ_TRUNCATED | READ_BITRATE))
+            if (m_hFile.OpenFile(m_fileName, READ_NO_BUFFER))
             {
                 break;
             }


### PR DESCRIPTION
v21.0.3
- Use READ_NO_BUFFER for opening files with Kodi Omega 21.1