### PR TITLE
Disable buffering to fix incompatibility with Kodi's file stream buffer

### DIFF
--- a/pvr.mediaportal.tvserver/addon.xml.in
+++ b/pvr.mediaportal.tvserver/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="22.1.0"
+  version="22.1.1"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mediaportal.tvserver/changelog.txt
+++ b/pvr.mediaportal.tvserver/changelog.txt
@@ -1,3 +1,6 @@
+v22.1.1
+- Disable buffering to fix incompatibility with Kodi's file stream buffer
+
 v22.1.0
 - PVR Add-on API v9.0.0
 

--- a/src/lib/tsreader/FileReader.cpp
+++ b/src/lib/tsreader/FileReader.cpp
@@ -57,6 +57,9 @@
 /* calcuate bitrate for file while reading */
 #define READ_BITRATE   0x10
 
+/* indicate that caller want open a file without intermediate buffer regardless to file type */
+#define READ_NO_BUFFER 0x200
+
 template<typename T> void SafeDelete(T*& p)
 {
   if (p)
@@ -69,7 +72,8 @@ namespace MPTV
 {
     FileReader::FileReader() :
         m_fileSize(0),
-        m_fileName("")
+        m_fileName(""),
+        m_flags(READ_NO_CACHE | READ_TRUNCATED | READ_BITRATE)
     {
     }
 
@@ -125,7 +129,7 @@ namespace MPTV
         do
         {
             kodi::Log(ADDON_LOG_INFO, "FileReader::OpenFile() %s.", m_fileName.c_str());
-            if (m_hFile.OpenFile(m_fileName, READ_NO_CACHE | READ_TRUNCATED | READ_BITRATE))
+            if (m_hFile.OpenFile(m_fileName, m_flags))
             {
                 break;
             }
@@ -202,6 +206,12 @@ namespace MPTV
     int64_t FileReader::GetFilePointer()
     {
         return m_hFile.GetPosition();
+    }
+
+
+    void FileReader::SetNoBuffer(void)
+    {
+        m_flags |= READ_NO_BUFFER;
     }
 
 

--- a/src/lib/tsreader/FileReader.h
+++ b/src/lib/tsreader/FileReader.h
@@ -58,10 +58,12 @@ namespace MPTV
         virtual bool IsBuffer() { return false; };
         virtual int64_t OnChannelChange(void);
         virtual size_t HasData(){ return 0; };
+        virtual void SetNoBuffer();
 
     protected:
         kodi::vfs::CFile m_hFile;         // Handle to file for streaming
         std::string m_fileName;           // The filename where we read from
         int64_t     m_fileSize;
+        uint32_t    m_flags;
     };
 }

--- a/src/lib/tsreader/MultiFileReader.cpp
+++ b/src/lib/tsreader/MultiFileReader.cpp
@@ -96,6 +96,11 @@ namespace MPTV
     //
     long MultiFileReader::OpenFile()
     {
+        // The underlying CFileStreamBuffer class used by kodi::vfs::CFile.Open() appears
+        // to be incompatible with the TS buffer files created by the TvServer, so disable
+        // the buffering.
+        m_TSBufferFile.SetNoBuffer();
+
         long hResult = m_TSBufferFile.OpenFile();
         kodi::Log(ADDON_LOG_DEBUG, "MultiFileReader: buffer file opened return code %d.", hResult);
 


### PR DESCRIPTION
The underlying CFileStreamBuffer class used by kodi::vfs::CFile.Open() appears to be incompatible with the TS buffer files created by the TvServer, so disable the buffering.

Dependent Kodi PR: https://github.com/xbmc/xbmc/pull/25834